### PR TITLE
Add some missing hand positions

### DIFF
--- a/1.1/Defs/Mods/CEGuns.xml
+++ b/1.1/Defs/Mods/CEGuns.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_CombatExtendedGuns</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.247, 0.100, -0.050)</MainHand>
+              <SecHand>(0.200, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeAMR</li> <!-- A-12 charge anti-materiel rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, 0.023)</MainHand>
+              <SecHand>(0.170, -0.100, 0.069)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_AKM</li> <!-- AKM -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.142, 0.100, -0.018)</MainHand>
+              <SecHand>(0.225, -0.100, -0.022)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_Crossbow</li> <!-- crossbow -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.279, 0.100, 0.005)</MainHand>
+              <SecHand>(0.202, -0.100, 0.019)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_FlintlockMusket</li> <!-- flintlock musket -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.146, 0.100, -0.027)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_FlintlockPistol</li> <!-- flintlock pistol -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.188, 0.100, -0.018)</MainHand>
+              <SecHand>(0.179, -0.100, 0.014)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_FNFAL</li> <!-- FN FAL -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, -0.073)</MainHand>
+              <SecHand>(0.106, -0.100, -0.041)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_HecateTwo</li> <!-- Hecate II -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, -0.091)</MainHand>
+              <SecHand>(0.124, -0.100, -0.078)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeLMG</li> <!-- L-8 charge LMG -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.188, 0.100, -0.050)</MainHand>
+              <SecHand>(0.133, -0.100, -0.018)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MSixty</li> <!-- M60E6 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.160, 0.100, -0.036)</MainHand>
+              <SecHand>(0.111, -0.100, -0.013)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MTwoFourNine</li> <!-- M249 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.201, 0.100, -0.114)</MainHand>
+              <SecHand>(0.239, -0.100, -0.128)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MilkorMGL</li> <!-- Milkor MGL -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.114, 0.100, -0.091)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargePistol</li> <!-- P-10 charge pistol -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.197, 0.100, -0.041)</MainHand>
+              <SecHand>(0.138, -0.100, -0.027)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_PKM</li> <!-- PKM -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.311, 0.100, 0.037)</MainHand>
+              <SecHand>(0.166, -0.100, 0.028)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_PTRS</li> <!-- PTRS-41 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.247, 0.100, -0.082)</MainHand>
+              <SecHand>(0.138, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeSniperRifle</li> <!-- R-8 charge sniper rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.325, 0.100, -0.096)</MainHand>
+              <SecHand>(0.088, -0.100, -0.059)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_Flamethrower</li> <!-- RM2 Flamethrower -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, -0.013)</MainHand>
+              <SecHand>(0.083, -0.100, 0.033)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_RPD</li> <!-- RPD -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.211, 0.100, -0.050)</MainHand>
+              <SecHand>(0.078, -0.100, -0.082)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_RPGSeven</li> <!-- RPG-7 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.123, 0.100, -0.018)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_SWGovernor</li> <!-- S&W Governor -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.169, 0.100, -0.027)</MainHand>
+              <SecHand>(0.317, -0.100, -0.013)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeShotgun</li> <!-- S-12 charge shotgun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.073, 0.100, -0.096)</MainHand>
+              <SecHand>(0.133, -0.100, -0.114)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeSMG</li> <!-- S-6 charge SMG -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, -0.078)</MainHand>
+              <SecHand>(0.120, -0.100, -0.036)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_SVD</li> <!-- SVD -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.018)</MainHand>
+              <SecHand>(0.166, -0.100, 0.042)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_USASTwelve</li> <!-- USAS-12 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.013)</MainHand>
+              <SecHand>(0.065, -0.100, -0.009)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_WinchesterNintyFour</li> <!-- Winchester 94 -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.1/Defs/Mods/CEGuns.xml
+++ b/1.1/Defs/Mods/CEGuns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="CETeam.CombatExtendedGuns">
      <defName>ClutterHandsSettings_CombatExtendedGuns</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.1/Defs/Mods/CETeam.CombatExtended.xml
+++ b/1.1/Defs/Mods/CETeam.CombatExtended.xml
@@ -49,6 +49,28 @@
           <!-- stick bomb -->
         </ThingTargets>
       </li>
+      <li>
+        <MainHand>(-0.004, 0.100, -0.078)</MainHand>
+        <ThingTargets>
+          <li>Weapon_GrenadeConcussion</li>
+          <!-- concussion grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.273, 0.100, -0.050)</MainHand>
+        <SecHand>(0.200, -0.100, -0.050)</SecHand>
+        <ThingTargets>
+          <li>CE_DisposableRocketLauncher</li>
+          <!-- M72 LAW -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.140, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>CE_FlareGun</li>
+          <!-- flare gun -->
+        </ThingTargets>
+      </li>
     </WeaponCompLoader>
   </WHands.ClutterHandsTDef>
 </Defs>

--- a/1.1/Defs/Mods/SparklingWorldsFullMod.xml
+++ b/1.1/Defs/Mods/SparklingWorldsFullMod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="Albion.SparklingWorlds.Full">
      <defName>ClutterHandsSettings_SparklingWorldsFullMod</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.1/Defs/Mods/SparklingWorldsFullMod.xml
+++ b/1.1/Defs/Mods/SparklingWorldsFullMod.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_SparklingWorldsFullMod</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(0.010, 0.100, -0.073)</MainHand>
+              <SecHand>(0.340, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>Gun_BulletstormSW</li> <!-- bulletstorm -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.000, 0.000, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>BurnStickSW</li> <!-- burn gauntlet -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.142, 0.100, -0.068)</MainHand>
+              <SecHand>(0.244, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>Gun_RailgunSW</li> <!-- gauss lance -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.087, 0.100, -0.050)</MainHand>
+              <SecHand>(0.234, -0.100, -0.027)</SecHand>
+              <ThingTargets>
+                 <li>Gun_GaussrifleSW</li> <!-- gauss rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.156, 0.100, -0.036)</MainHand>
+              <ThingTargets>
+                 <li>Gun_PainGunSW</li> <!-- pain gun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.293, 0.100, -0.027)</MainHand>
+              <ThingTargets>
+                 <li>PainStickSW</li> <!-- pain stick -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.100, 0.100, -0.110)</MainHand>
+              <SecHand>(0.225, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>Gun_PlasmaGunSW</li> <!-- plasma gun -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.1/Defs/Mods/VFEC.xml
+++ b/1.1/Defs/Mods/VFEC.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="OskarPotocki.VFE.Classical">
      <defName>ClutterHandsSettings_VanillaFactionsExpandedClassical</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.1/Defs/Mods/VFEC.xml
+++ b/1.1/Defs/Mods/VFEC.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedClassical</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.169, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_MeleeWeapon_Dagger</li> <!-- dagger -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.385, 0.100, -0.013)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_Javelin</li> <!-- javelin -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.334, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_MeleeWeapon_Spatha</li> <!-- spatha -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.000, 0.000, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_Weapon_Scorpion</li> <!-- scorpion -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.1/Defs/Mods/VFEP.xml
+++ b/1.1/Defs/Mods/VFEP.xml
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedPirates</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.266, 0.100, -0.105)</MainHand>
+              <SecHand>(0.046, -0.100, -0.169)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Autorifle</li> <!-- warcasket autorifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.321, 0.100, -0.357)</MainHand>
+              <SecHand>(-0.229, -0.100, -0.270)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_Broadsword</li> <!-- warcasket broadsword -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.371, 0.100, 0.010)</MainHand>
+              <SecHand>(0.156, -0.100, -0.165)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_ChargeBlaster</li> <!-- warcasket charge blaster -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, 0.133)</MainHand>
+              <SecHand>(0.216, -0.100, -0.123)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_ChargeLance</li> <!-- warcasket charge lance -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.009)</MainHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_CombatKnife</li> <!-- warcasket combat knife -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.311, 0.100, 0.088)</MainHand>
+              <SecHand>(0.014, -0.100, 0.166)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_CryptoCannon</li> <!-- warcasket crypto cannon -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.302, 0.100, -0.105)</MainHand>
+              <SecHand>(-0.027, -0.100, 0.083)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_FoldingGun</li> <!-- warcasket folding gun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.307, 0.100, -0.293)</MainHand>
+              <SecHand>(-0.091, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_GravityHammer</li> <!-- warcasket gravity hammer -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.362, 0.100, -0.215)</MainHand>
+              <SecHand>(0.124, -0.100, -0.146)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_GrenadeLauncher</li> <!-- warcasket grenade launcher -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.288, 0.100, -0.078)</MainHand>
+              <SecHand>(0.106, -0.100, 0.166)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_HandheldCannon</li> <!-- warcasket handheld cannon -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.325, 0.100, 0.179)</MainHand>
+              <SecHand>(0.042, -0.100, 0.184)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_HeavyFlamer</li> <!-- warcasket heavy flamer -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.348, 0.100, 0.198)</MainHand>
+              <SecHand>(-0.087, -0.100, 0.170)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Minigun</li> <!-- warcasket minigun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.289, 0.100, -0.298)</MainHand>
+              <SecHand>(-0.078, -0.100, 0.088)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Railgun</li> <!-- warcasket railgun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.238, 0.100, -0.078)</MainHand>
+              <SecHand>(0.065, -0.100, -0.123)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Slugthrower</li> <!-- warcasket slugthrower -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.256, 0.100, -0.087)</MainHand>
+              <SecHand>(0.042, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_UraniumSlugRifle</li> <!-- warcasket uranium slug rifle -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.1/Defs/Mods/VFEP.xml
+++ b/1.1/Defs/Mods/VFEP.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="OskarPotocki.VFE.Pirates">
      <defName>ClutterHandsSettings_VanillaFactionsExpandedPirates</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.1/Defs/Mods/VFES.xml
+++ b/1.1/Defs/Mods/VFES.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedSettlers</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.261, 0.100, -0.321)</MainHand>
+              <ThingTargets>
+                 <li>VFES_Gun_DoubleActionRevolver</li> <!-- Colt SAA -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.091, 0.100, -0.082)</MainHand>
+              <SecHand>(0.092, 0.100, -0.128)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Weapon_GrenadeDynamite</li> <!-- dynamite -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.279, 0.100, -0.045)</MainHand>
+              <SecHand>(0.267, -0.100, -0.018)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Gun_HuntingRifle</li> <!-- M1903 Springfield -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.128)</MainHand>
+              <ThingTargets>
+                 <li>VFES_Tomahawk</li> <!-- tomahawk -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.220, 0.100, -0.055)</MainHand>
+              <SecHand>(0.078, -0.100, -0.036)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Gun_DoubleBarreledShotgun</li> <!-- Winchester M21 -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.1/Defs/Mods/VPE.xml
+++ b/1.1/Defs/Mods/VPE.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaPsycastsExpanded</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.188, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexDagger</li> <!-- eltex dagger -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.151, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexMace</li> <!-- eltex mace -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.261, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexSword</li> <!-- eltex sword -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.1/Defs/Mods/VPE.xml
+++ b/1.1/Defs/Mods/VPE.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="VanillaExpanded.VPsycastsE">
      <defName>ClutterHandsSettings_VanillaPsycastsExpanded</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.1/Defs/Mods/VTE.xml
+++ b/1.1/Defs/Mods/VTE.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="VanillaExpanded.VTEXE">
+     <defName>ClutterHandsSettings_Core_VanillaTexturesExpanded</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.243, 0.100, 0.014)</MainHand>
+              <SecHand>(0.248, -0.100, 0.042)</SecHand>
+              <ThingTargets>
+                 <li>Gun_BoltActionRifle</li> <!-- Lee-Enfield -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.183, 0.100, -0.055)</MainHand>
+              <SecHand>(0.202, -0.100, 0.005)</SecHand>
+              <ThingTargets>
+                 <li>Gun_AssaultRifle</li> <!-- M16A3 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.120, 0.100, -0.041)</MainHand>
+              <ThingTargets>
+                 <li>Gun_MachinePistol</li> <!-- MAC-10 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.105, 0.100, 0.022)</MainHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Mace</li> <!-- mace -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.444, 0.100, -0.082)</MainHand>
+              <SecHand>(-0.114, -0.100, 0.019)</SecHand>
+              <ThingTargets>
+                 <li>Gun_Minigun</li> <!-- minigun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.156, 0.100, -0.021)</MainHand>
+              <SecHand>(0.200, -0.100, 0.028)</SecHand>
+              <ThingTargets>
+                 <li>Gun_ChainShotgun</li> <!-- Saiga 12K -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.266, 0.100, -0.247)</MainHand>
+              <SecHand>(-0.009, -0.100, 0.000)</SecHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Spear</li> <!-- spear -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.055, 0.100, -0.174)</MainHand>
+              <SecHand>(0.253, -0.100, -0.142)</SecHand>
+              <ThingTargets>
+                 <li>Gun_HeavySMG</li> <!-- UMP45 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.220, 0.100, -0.059)</MainHand>
+              <SecHand>(0.106, -0.100, 0.253)</SecHand>
+              <ThingTargets>
+                 <li>WoodLog</li> <!-- wood -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, 0.005)</MainHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Ikwa</li> <!-- ikwa -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.068, 0.100, -0.082)</MainHand>
+              <ThingTargets>
+                 <li>Weapon_GrenadeEMP</li> <!-- EMP grenade -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.041, 0.100, -0.050)</MainHand>
+              <ThingTargets>
+                 <li>Weapon_GrenadeFrag</li> <!-- frag grenade -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.144, 0.100, 0.000)</MainHand>
+              <SecHand>(0.000, -0.100, 0.000)</SecHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_BreachAxe</li> <!-- breach axe -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.1/Defs/Mods/VWEFT.xml
+++ b/1.1/Defs/Mods/VWEFT.xml
@@ -42,6 +42,43 @@
           <!-- volcanic pistol -->
         </ThingTargets>
       </li>
+      <li>
+        <MainHand>(-0.215, 0.100, -0.032)</MainHand>
+        <SecHand>(0.230, -0.100, 0.005)</SecHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_GaussRepeater</li>
+          <!-- gauss repeater -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.247, 0.100, -0.050)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_GaussRevolver</li>
+          <!-- gauss revolver -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.403, 0.100, 0.051)</MainHand>
+        <SecHand>(-0.156, -0.100, -0.233)</SecHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_HandheldGatlingGun</li>
+          <!-- handheld gatling gun -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.178, 0.100, -0.078)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_Derringer</li>
+          <!-- Remington M95 -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.275, 0.100, -0.073)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_LeverActionShotgun</li>
+          <!-- Winchester M1887 (sawed-off) -->
+        </ThingTargets>
+      </li>
     </WeaponCompLoader>
   </WHands.ClutterHandsTDef>
 </Defs>

--- a/1.2/Defs/Mods/CEGuns.xml
+++ b/1.2/Defs/Mods/CEGuns.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_CombatExtendedGuns</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.247, 0.100, -0.050)</MainHand>
+              <SecHand>(0.200, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeAMR</li> <!-- A-12 charge anti-materiel rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, 0.023)</MainHand>
+              <SecHand>(0.170, -0.100, 0.069)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_AKM</li> <!-- AKM -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.142, 0.100, -0.018)</MainHand>
+              <SecHand>(0.225, -0.100, -0.022)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_Crossbow</li> <!-- crossbow -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.279, 0.100, 0.005)</MainHand>
+              <SecHand>(0.202, -0.100, 0.019)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_FlintlockMusket</li> <!-- flintlock musket -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.146, 0.100, -0.027)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_FlintlockPistol</li> <!-- flintlock pistol -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.188, 0.100, -0.018)</MainHand>
+              <SecHand>(0.179, -0.100, 0.014)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_FNFAL</li> <!-- FN FAL -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, -0.073)</MainHand>
+              <SecHand>(0.106, -0.100, -0.041)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_HecateTwo</li> <!-- Hecate II -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, -0.091)</MainHand>
+              <SecHand>(0.124, -0.100, -0.078)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeLMG</li> <!-- L-8 charge LMG -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.188, 0.100, -0.050)</MainHand>
+              <SecHand>(0.133, -0.100, -0.018)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MSixty</li> <!-- M60E6 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.160, 0.100, -0.036)</MainHand>
+              <SecHand>(0.111, -0.100, -0.013)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MTwoFourNine</li> <!-- M249 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.201, 0.100, -0.114)</MainHand>
+              <SecHand>(0.239, -0.100, -0.128)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MilkorMGL</li> <!-- Milkor MGL -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.114, 0.100, -0.091)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargePistol</li> <!-- P-10 charge pistol -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.197, 0.100, -0.041)</MainHand>
+              <SecHand>(0.138, -0.100, -0.027)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_PKM</li> <!-- PKM -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.311, 0.100, 0.037)</MainHand>
+              <SecHand>(0.166, -0.100, 0.028)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_PTRS</li> <!-- PTRS-41 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.247, 0.100, -0.082)</MainHand>
+              <SecHand>(0.138, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeSniperRifle</li> <!-- R-8 charge sniper rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.325, 0.100, -0.096)</MainHand>
+              <SecHand>(0.088, -0.100, -0.059)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_Flamethrower</li> <!-- RM2 Flamethrower -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, -0.013)</MainHand>
+              <SecHand>(0.083, -0.100, 0.033)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_RPD</li> <!-- RPD -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.211, 0.100, -0.050)</MainHand>
+              <SecHand>(0.078, -0.100, -0.082)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_RPGSeven</li> <!-- RPG-7 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.123, 0.100, -0.018)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_SWGovernor</li> <!-- S&W Governor -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.169, 0.100, -0.027)</MainHand>
+              <SecHand>(0.317, -0.100, -0.013)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeShotgun</li> <!-- S-12 charge shotgun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.073, 0.100, -0.096)</MainHand>
+              <SecHand>(0.133, -0.100, -0.114)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeSMG</li> <!-- S-6 charge SMG -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, -0.078)</MainHand>
+              <SecHand>(0.120, -0.100, -0.036)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_SVD</li> <!-- SVD -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.018)</MainHand>
+              <SecHand>(0.166, -0.100, 0.042)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_USASTwelve</li> <!-- USAS-12 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.013)</MainHand>
+              <SecHand>(0.065, -0.100, -0.009)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_WinchesterNintyFour</li> <!-- Winchester 94 -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.2/Defs/Mods/CEGuns.xml
+++ b/1.2/Defs/Mods/CEGuns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="CETeam.CombatExtendedGuns">
      <defName>ClutterHandsSettings_CombatExtendedGuns</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.2/Defs/Mods/CETeam.CombatExtended.xml
+++ b/1.2/Defs/Mods/CETeam.CombatExtended.xml
@@ -49,6 +49,28 @@
           <!-- stick bomb -->
         </ThingTargets>
       </li>
+      <li>
+        <MainHand>(-0.004, 0.100, -0.078)</MainHand>
+        <ThingTargets>
+          <li>Weapon_GrenadeConcussion</li>
+          <!-- concussion grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.273, 0.100, -0.050)</MainHand>
+        <SecHand>(0.200, -0.100, -0.050)</SecHand>
+        <ThingTargets>
+          <li>CE_DisposableRocketLauncher</li>
+          <!-- M72 LAW -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.140, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>CE_FlareGun</li>
+          <!-- flare gun -->
+        </ThingTargets>
+      </li>
     </WeaponCompLoader>
   </WHands.ClutterHandsTDef>
 </Defs>

--- a/1.2/Defs/Mods/SparklingWorldsFullMod.xml
+++ b/1.2/Defs/Mods/SparklingWorldsFullMod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="Albion.SparklingWorlds.Full">
      <defName>ClutterHandsSettings_SparklingWorldsFullMod</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.2/Defs/Mods/SparklingWorldsFullMod.xml
+++ b/1.2/Defs/Mods/SparklingWorldsFullMod.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_SparklingWorldsFullMod</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(0.010, 0.100, -0.073)</MainHand>
+              <SecHand>(0.340, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>Gun_BulletstormSW</li> <!-- bulletstorm -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.000, 0.000, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>BurnStickSW</li> <!-- burn gauntlet -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.142, 0.100, -0.068)</MainHand>
+              <SecHand>(0.244, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>Gun_RailgunSW</li> <!-- gauss lance -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.087, 0.100, -0.050)</MainHand>
+              <SecHand>(0.234, -0.100, -0.027)</SecHand>
+              <ThingTargets>
+                 <li>Gun_GaussrifleSW</li> <!-- gauss rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.156, 0.100, -0.036)</MainHand>
+              <ThingTargets>
+                 <li>Gun_PainGunSW</li> <!-- pain gun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.293, 0.100, -0.027)</MainHand>
+              <ThingTargets>
+                 <li>PainStickSW</li> <!-- pain stick -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.100, 0.100, -0.110)</MainHand>
+              <SecHand>(0.225, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>Gun_PlasmaGunSW</li> <!-- plasma gun -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.2/Defs/Mods/VFEC.xml
+++ b/1.2/Defs/Mods/VFEC.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="OskarPotocki.VFE.Classical">
      <defName>ClutterHandsSettings_VanillaFactionsExpandedClassical</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.2/Defs/Mods/VFEC.xml
+++ b/1.2/Defs/Mods/VFEC.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedClassical</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.169, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_MeleeWeapon_Dagger</li> <!-- dagger -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.385, 0.100, -0.013)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_Javelin</li> <!-- javelin -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.334, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_MeleeWeapon_Spatha</li> <!-- spatha -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.000, 0.000, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_Weapon_Scorpion</li> <!-- scorpion -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.2/Defs/Mods/VFEP.xml
+++ b/1.2/Defs/Mods/VFEP.xml
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedPirates</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.266, 0.100, -0.105)</MainHand>
+              <SecHand>(0.046, -0.100, -0.169)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Autorifle</li> <!-- warcasket autorifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.321, 0.100, -0.357)</MainHand>
+              <SecHand>(-0.229, -0.100, -0.270)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_Broadsword</li> <!-- warcasket broadsword -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.371, 0.100, 0.010)</MainHand>
+              <SecHand>(0.156, -0.100, -0.165)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_ChargeBlaster</li> <!-- warcasket charge blaster -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, 0.133)</MainHand>
+              <SecHand>(0.216, -0.100, -0.123)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_ChargeLance</li> <!-- warcasket charge lance -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.009)</MainHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_CombatKnife</li> <!-- warcasket combat knife -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.311, 0.100, 0.088)</MainHand>
+              <SecHand>(0.014, -0.100, 0.166)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_CryptoCannon</li> <!-- warcasket crypto cannon -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.302, 0.100, -0.105)</MainHand>
+              <SecHand>(-0.027, -0.100, 0.083)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_FoldingGun</li> <!-- warcasket folding gun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.307, 0.100, -0.293)</MainHand>
+              <SecHand>(-0.091, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_GravityHammer</li> <!-- warcasket gravity hammer -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.362, 0.100, -0.215)</MainHand>
+              <SecHand>(0.124, -0.100, -0.146)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_GrenadeLauncher</li> <!-- warcasket grenade launcher -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.288, 0.100, -0.078)</MainHand>
+              <SecHand>(0.106, -0.100, 0.166)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_HandheldCannon</li> <!-- warcasket handheld cannon -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.325, 0.100, 0.179)</MainHand>
+              <SecHand>(0.042, -0.100, 0.184)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_HeavyFlamer</li> <!-- warcasket heavy flamer -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.348, 0.100, 0.198)</MainHand>
+              <SecHand>(-0.087, -0.100, 0.170)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Minigun</li> <!-- warcasket minigun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.289, 0.100, -0.298)</MainHand>
+              <SecHand>(-0.078, -0.100, 0.088)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Railgun</li> <!-- warcasket railgun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.238, 0.100, -0.078)</MainHand>
+              <SecHand>(0.065, -0.100, -0.123)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Slugthrower</li> <!-- warcasket slugthrower -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.256, 0.100, -0.087)</MainHand>
+              <SecHand>(0.042, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_UraniumSlugRifle</li> <!-- warcasket uranium slug rifle -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.2/Defs/Mods/VFEP.xml
+++ b/1.2/Defs/Mods/VFEP.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="OskarPotocki.VFE.Pirates">
      <defName>ClutterHandsSettings_VanillaFactionsExpandedPirates</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.2/Defs/Mods/VFES.xml
+++ b/1.2/Defs/Mods/VFES.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedSettlers</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.261, 0.100, -0.321)</MainHand>
+              <ThingTargets>
+                 <li>VFES_Gun_DoubleActionRevolver</li> <!-- Colt SAA -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.091, 0.100, -0.082)</MainHand>
+              <SecHand>(0.092, 0.100, -0.128)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Weapon_GrenadeDynamite</li> <!-- dynamite -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.279, 0.100, -0.045)</MainHand>
+              <SecHand>(0.267, -0.100, -0.018)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Gun_HuntingRifle</li> <!-- M1903 Springfield -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.128)</MainHand>
+              <ThingTargets>
+                 <li>VFES_Tomahawk</li> <!-- tomahawk -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.220, 0.100, -0.055)</MainHand>
+              <SecHand>(0.078, -0.100, -0.036)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Gun_DoubleBarreledShotgun</li> <!-- Winchester M21 -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.2/Defs/Mods/VPE.xml
+++ b/1.2/Defs/Mods/VPE.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaPsycastsExpanded</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.188, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexDagger</li> <!-- eltex dagger -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.151, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexMace</li> <!-- eltex mace -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.261, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexSword</li> <!-- eltex sword -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.2/Defs/Mods/VPE.xml
+++ b/1.2/Defs/Mods/VPE.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="VanillaExpanded.VPsycastsE">
      <defName>ClutterHandsSettings_VanillaPsycastsExpanded</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.2/Defs/Mods/VTE.xml
+++ b/1.2/Defs/Mods/VTE.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="VanillaExpanded.VTEXE">
+     <defName>ClutterHandsSettings_Core_VanillaTexturesExpanded</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.243, 0.100, 0.014)</MainHand>
+              <SecHand>(0.248, -0.100, 0.042)</SecHand>
+              <ThingTargets>
+                 <li>Gun_BoltActionRifle</li> <!-- Lee-Enfield -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.183, 0.100, -0.055)</MainHand>
+              <SecHand>(0.202, -0.100, 0.005)</SecHand>
+              <ThingTargets>
+                 <li>Gun_AssaultRifle</li> <!-- M16A3 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.120, 0.100, -0.041)</MainHand>
+              <ThingTargets>
+                 <li>Gun_MachinePistol</li> <!-- MAC-10 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.105, 0.100, 0.022)</MainHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Mace</li> <!-- mace -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.444, 0.100, -0.082)</MainHand>
+              <SecHand>(-0.114, -0.100, 0.019)</SecHand>
+              <ThingTargets>
+                 <li>Gun_Minigun</li> <!-- minigun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.156, 0.100, -0.021)</MainHand>
+              <SecHand>(0.200, -0.100, 0.028)</SecHand>
+              <ThingTargets>
+                 <li>Gun_ChainShotgun</li> <!-- Saiga 12K -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.266, 0.100, -0.247)</MainHand>
+              <SecHand>(-0.009, -0.100, 0.000)</SecHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Spear</li> <!-- spear -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.055, 0.100, -0.174)</MainHand>
+              <SecHand>(0.253, -0.100, -0.142)</SecHand>
+              <ThingTargets>
+                 <li>Gun_HeavySMG</li> <!-- UMP45 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.220, 0.100, -0.059)</MainHand>
+              <SecHand>(0.106, -0.100, 0.253)</SecHand>
+              <ThingTargets>
+                 <li>WoodLog</li> <!-- wood -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, 0.005)</MainHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Ikwa</li> <!-- ikwa -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.068, 0.100, -0.082)</MainHand>
+              <ThingTargets>
+                 <li>Weapon_GrenadeEMP</li> <!-- EMP grenade -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.041, 0.100, -0.050)</MainHand>
+              <ThingTargets>
+                 <li>Weapon_GrenadeFrag</li> <!-- frag grenade -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.144, 0.100, 0.000)</MainHand>
+              <SecHand>(0.000, -0.100, 0.000)</SecHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_BreachAxe</li> <!-- breach axe -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.2/Defs/Mods/VWEFT.xml
+++ b/1.2/Defs/Mods/VWEFT.xml
@@ -42,6 +42,43 @@
           <!-- volcanic pistol -->
         </ThingTargets>
       </li>
+      <li>
+        <MainHand>(-0.215, 0.100, -0.032)</MainHand>
+        <SecHand>(0.230, -0.100, 0.005)</SecHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_GaussRepeater</li>
+          <!-- gauss repeater -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.247, 0.100, -0.050)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_GaussRevolver</li>
+          <!-- gauss revolver -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.403, 0.100, 0.051)</MainHand>
+        <SecHand>(-0.156, -0.100, -0.233)</SecHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_HandheldGatlingGun</li>
+          <!-- handheld gatling gun -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.178, 0.100, -0.078)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_Derringer</li>
+          <!-- Remington M95 -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.275, 0.100, -0.073)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_LeverActionShotgun</li>
+          <!-- Winchester M1887 (sawed-off) -->
+        </ThingTargets>
+      </li>
     </WeaponCompLoader>
   </WHands.ClutterHandsTDef>
 </Defs>

--- a/1.3/Defs/Mods/CEGuns.xml
+++ b/1.3/Defs/Mods/CEGuns.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_CombatExtendedGuns</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.247, 0.100, -0.050)</MainHand>
+              <SecHand>(0.200, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeAMR</li> <!-- A-12 charge anti-materiel rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, 0.023)</MainHand>
+              <SecHand>(0.170, -0.100, 0.069)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_AKM</li> <!-- AKM -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.142, 0.100, -0.018)</MainHand>
+              <SecHand>(0.225, -0.100, -0.022)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_Crossbow</li> <!-- crossbow -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.279, 0.100, 0.005)</MainHand>
+              <SecHand>(0.202, -0.100, 0.019)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_FlintlockMusket</li> <!-- flintlock musket -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.146, 0.100, -0.027)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_FlintlockPistol</li> <!-- flintlock pistol -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.188, 0.100, -0.018)</MainHand>
+              <SecHand>(0.179, -0.100, 0.014)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_FNFAL</li> <!-- FN FAL -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, -0.073)</MainHand>
+              <SecHand>(0.106, -0.100, -0.041)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_HecateTwo</li> <!-- Hecate II -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, -0.091)</MainHand>
+              <SecHand>(0.124, -0.100, -0.078)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeLMG</li> <!-- L-8 charge LMG -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.188, 0.100, -0.050)</MainHand>
+              <SecHand>(0.133, -0.100, -0.018)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MSixty</li> <!-- M60E6 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.160, 0.100, -0.036)</MainHand>
+              <SecHand>(0.111, -0.100, -0.013)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MTwoFourNine</li> <!-- M249 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.201, 0.100, -0.114)</MainHand>
+              <SecHand>(0.239, -0.100, -0.128)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MilkorMGL</li> <!-- Milkor MGL -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.114, 0.100, -0.091)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargePistol</li> <!-- P-10 charge pistol -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.197, 0.100, -0.041)</MainHand>
+              <SecHand>(0.138, -0.100, -0.027)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_PKM</li> <!-- PKM -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.311, 0.100, 0.037)</MainHand>
+              <SecHand>(0.166, -0.100, 0.028)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_PTRS</li> <!-- PTRS-41 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.247, 0.100, -0.082)</MainHand>
+              <SecHand>(0.138, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeSniperRifle</li> <!-- R-8 charge sniper rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.325, 0.100, -0.096)</MainHand>
+              <SecHand>(0.088, -0.100, -0.059)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_Flamethrower</li> <!-- RM2 Flamethrower -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, -0.013)</MainHand>
+              <SecHand>(0.083, -0.100, 0.033)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_RPD</li> <!-- RPD -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.211, 0.100, -0.050)</MainHand>
+              <SecHand>(0.078, -0.100, -0.082)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_RPGSeven</li> <!-- RPG-7 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.123, 0.100, -0.018)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_SWGovernor</li> <!-- S&W Governor -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.169, 0.100, -0.027)</MainHand>
+              <SecHand>(0.317, -0.100, -0.013)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeShotgun</li> <!-- S-12 charge shotgun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.073, 0.100, -0.096)</MainHand>
+              <SecHand>(0.133, -0.100, -0.114)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeSMG</li> <!-- S-6 charge SMG -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, -0.078)</MainHand>
+              <SecHand>(0.120, -0.100, -0.036)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_SVD</li> <!-- SVD -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.018)</MainHand>
+              <SecHand>(0.166, -0.100, 0.042)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_USASTwelve</li> <!-- USAS-12 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.013)</MainHand>
+              <SecHand>(0.065, -0.100, -0.009)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_WinchesterNintyFour</li> <!-- Winchester 94 -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.3/Defs/Mods/CEGuns.xml
+++ b/1.3/Defs/Mods/CEGuns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="CETeam.CombatExtendedGuns">
      <defName>ClutterHandsSettings_CombatExtendedGuns</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.3/Defs/Mods/CETeam.CombatExtended.xml
+++ b/1.3/Defs/Mods/CETeam.CombatExtended.xml
@@ -49,6 +49,28 @@
           <!-- stick bomb -->
         </ThingTargets>
       </li>
+      <li>
+        <MainHand>(-0.004, 0.100, -0.078)</MainHand>
+        <ThingTargets>
+          <li>Weapon_GrenadeConcussion</li>
+          <!-- concussion grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.273, 0.100, -0.050)</MainHand>
+        <SecHand>(0.200, -0.100, -0.050)</SecHand>
+        <ThingTargets>
+          <li>CE_DisposableRocketLauncher</li>
+          <!-- M72 LAW -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.140, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>CE_FlareGun</li>
+          <!-- flare gun -->
+        </ThingTargets>
+      </li>
     </WeaponCompLoader>
   </WHands.ClutterHandsTDef>
 </Defs>

--- a/1.3/Defs/Mods/SparklingWorldsFullMod.xml
+++ b/1.3/Defs/Mods/SparklingWorldsFullMod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="Albion.SparklingWorlds.Full">
      <defName>ClutterHandsSettings_SparklingWorldsFullMod</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.3/Defs/Mods/SparklingWorldsFullMod.xml
+++ b/1.3/Defs/Mods/SparklingWorldsFullMod.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_SparklingWorldsFullMod</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(0.010, 0.100, -0.073)</MainHand>
+              <SecHand>(0.340, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>Gun_BulletstormSW</li> <!-- bulletstorm -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.000, 0.000, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>BurnStickSW</li> <!-- burn gauntlet -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.142, 0.100, -0.068)</MainHand>
+              <SecHand>(0.244, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>Gun_RailgunSW</li> <!-- gauss lance -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.087, 0.100, -0.050)</MainHand>
+              <SecHand>(0.234, -0.100, -0.027)</SecHand>
+              <ThingTargets>
+                 <li>Gun_GaussrifleSW</li> <!-- gauss rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.156, 0.100, -0.036)</MainHand>
+              <ThingTargets>
+                 <li>Gun_PainGunSW</li> <!-- pain gun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.293, 0.100, -0.027)</MainHand>
+              <ThingTargets>
+                 <li>PainStickSW</li> <!-- pain stick -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.100, 0.100, -0.110)</MainHand>
+              <SecHand>(0.225, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>Gun_PlasmaGunSW</li> <!-- plasma gun -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.3/Defs/Mods/VFEC.xml
+++ b/1.3/Defs/Mods/VFEC.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="OskarPotocki.VFE.Classical">
      <defName>ClutterHandsSettings_VanillaFactionsExpandedClassical</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.3/Defs/Mods/VFEC.xml
+++ b/1.3/Defs/Mods/VFEC.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedClassical</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.169, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_MeleeWeapon_Dagger</li> <!-- dagger -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.385, 0.100, -0.013)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_Javelin</li> <!-- javelin -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.334, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_MeleeWeapon_Spatha</li> <!-- spatha -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.000, 0.000, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_Weapon_Scorpion</li> <!-- scorpion -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.3/Defs/Mods/VFEP.xml
+++ b/1.3/Defs/Mods/VFEP.xml
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedPirates</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.266, 0.100, -0.105)</MainHand>
+              <SecHand>(0.046, -0.100, -0.169)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Autorifle</li> <!-- warcasket autorifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.321, 0.100, -0.357)</MainHand>
+              <SecHand>(-0.229, -0.100, -0.270)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_Broadsword</li> <!-- warcasket broadsword -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.371, 0.100, 0.010)</MainHand>
+              <SecHand>(0.156, -0.100, -0.165)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_ChargeBlaster</li> <!-- warcasket charge blaster -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, 0.133)</MainHand>
+              <SecHand>(0.216, -0.100, -0.123)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_ChargeLance</li> <!-- warcasket charge lance -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.009)</MainHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_CombatKnife</li> <!-- warcasket combat knife -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.311, 0.100, 0.088)</MainHand>
+              <SecHand>(0.014, -0.100, 0.166)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_CryptoCannon</li> <!-- warcasket crypto cannon -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.302, 0.100, -0.105)</MainHand>
+              <SecHand>(-0.027, -0.100, 0.083)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_FoldingGun</li> <!-- warcasket folding gun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.307, 0.100, -0.293)</MainHand>
+              <SecHand>(-0.091, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_GravityHammer</li> <!-- warcasket gravity hammer -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.362, 0.100, -0.215)</MainHand>
+              <SecHand>(0.124, -0.100, -0.146)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_GrenadeLauncher</li> <!-- warcasket grenade launcher -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.288, 0.100, -0.078)</MainHand>
+              <SecHand>(0.106, -0.100, 0.166)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_HandheldCannon</li> <!-- warcasket handheld cannon -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.325, 0.100, 0.179)</MainHand>
+              <SecHand>(0.042, -0.100, 0.184)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_HeavyFlamer</li> <!-- warcasket heavy flamer -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.348, 0.100, 0.198)</MainHand>
+              <SecHand>(-0.087, -0.100, 0.170)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Minigun</li> <!-- warcasket minigun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.289, 0.100, -0.298)</MainHand>
+              <SecHand>(-0.078, -0.100, 0.088)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Railgun</li> <!-- warcasket railgun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.238, 0.100, -0.078)</MainHand>
+              <SecHand>(0.065, -0.100, -0.123)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Slugthrower</li> <!-- warcasket slugthrower -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.256, 0.100, -0.087)</MainHand>
+              <SecHand>(0.042, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_UraniumSlugRifle</li> <!-- warcasket uranium slug rifle -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.3/Defs/Mods/VFEP.xml
+++ b/1.3/Defs/Mods/VFEP.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="OskarPotocki.VFE.Pirates">
      <defName>ClutterHandsSettings_VanillaFactionsExpandedPirates</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.3/Defs/Mods/VFES.xml
+++ b/1.3/Defs/Mods/VFES.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedSettlers</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.261, 0.100, -0.321)</MainHand>
+              <ThingTargets>
+                 <li>VFES_Gun_DoubleActionRevolver</li> <!-- Colt SAA -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.091, 0.100, -0.082)</MainHand>
+              <SecHand>(0.092, 0.100, -0.128)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Weapon_GrenadeDynamite</li> <!-- dynamite -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.279, 0.100, -0.045)</MainHand>
+              <SecHand>(0.267, -0.100, -0.018)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Gun_HuntingRifle</li> <!-- M1903 Springfield -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.128)</MainHand>
+              <ThingTargets>
+                 <li>VFES_Tomahawk</li> <!-- tomahawk -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.220, 0.100, -0.055)</MainHand>
+              <SecHand>(0.078, -0.100, -0.036)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Gun_DoubleBarreledShotgun</li> <!-- Winchester M21 -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.3/Defs/Mods/VPE.xml
+++ b/1.3/Defs/Mods/VPE.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaPsycastsExpanded</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.188, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexDagger</li> <!-- eltex dagger -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.151, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexMace</li> <!-- eltex mace -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.261, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexSword</li> <!-- eltex sword -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.3/Defs/Mods/VPE.xml
+++ b/1.3/Defs/Mods/VPE.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="VanillaExpanded.VPsycastsE">
      <defName>ClutterHandsSettings_VanillaPsycastsExpanded</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.3/Defs/Mods/VTE.xml
+++ b/1.3/Defs/Mods/VTE.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="VanillaExpanded.VTEXE">
+     <defName>ClutterHandsSettings_Core_VanillaTexturesExpanded</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.243, 0.100, 0.014)</MainHand>
+              <SecHand>(0.248, -0.100, 0.042)</SecHand>
+              <ThingTargets>
+                 <li>Gun_BoltActionRifle</li> <!-- Lee-Enfield -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.183, 0.100, -0.055)</MainHand>
+              <SecHand>(0.202, -0.100, 0.005)</SecHand>
+              <ThingTargets>
+                 <li>Gun_AssaultRifle</li> <!-- M16A3 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.120, 0.100, -0.041)</MainHand>
+              <ThingTargets>
+                 <li>Gun_MachinePistol</li> <!-- MAC-10 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.105, 0.100, 0.022)</MainHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Mace</li> <!-- mace -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.444, 0.100, -0.082)</MainHand>
+              <SecHand>(-0.114, -0.100, 0.019)</SecHand>
+              <ThingTargets>
+                 <li>Gun_Minigun</li> <!-- minigun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.156, 0.100, -0.021)</MainHand>
+              <SecHand>(0.200, -0.100, 0.028)</SecHand>
+              <ThingTargets>
+                 <li>Gun_ChainShotgun</li> <!-- Saiga 12K -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.266, 0.100, -0.247)</MainHand>
+              <SecHand>(-0.009, -0.100, 0.000)</SecHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Spear</li> <!-- spear -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.055, 0.100, -0.174)</MainHand>
+              <SecHand>(0.253, -0.100, -0.142)</SecHand>
+              <ThingTargets>
+                 <li>Gun_HeavySMG</li> <!-- UMP45 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.220, 0.100, -0.059)</MainHand>
+              <SecHand>(0.106, -0.100, 0.253)</SecHand>
+              <ThingTargets>
+                 <li>WoodLog</li> <!-- wood -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, 0.005)</MainHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Ikwa</li> <!-- ikwa -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.068, 0.100, -0.082)</MainHand>
+              <ThingTargets>
+                 <li>Weapon_GrenadeEMP</li> <!-- EMP grenade -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.041, 0.100, -0.050)</MainHand>
+              <ThingTargets>
+                 <li>Weapon_GrenadeFrag</li> <!-- frag grenade -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.144, 0.100, 0.000)</MainHand>
+              <SecHand>(0.000, -0.100, 0.000)</SecHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_BreachAxe</li> <!-- breach axe -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.3/Defs/Mods/VWEFT.xml
+++ b/1.3/Defs/Mods/VWEFT.xml
@@ -42,6 +42,43 @@
           <!-- volcanic pistol -->
         </ThingTargets>
       </li>
+      <li>
+        <MainHand>(-0.215, 0.100, -0.032)</MainHand>
+        <SecHand>(0.230, -0.100, 0.005)</SecHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_GaussRepeater</li>
+          <!-- gauss repeater -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.247, 0.100, -0.050)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_GaussRevolver</li>
+          <!-- gauss revolver -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.403, 0.100, 0.051)</MainHand>
+        <SecHand>(-0.156, -0.100, -0.233)</SecHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_HandheldGatlingGun</li>
+          <!-- handheld gatling gun -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.178, 0.100, -0.078)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_Derringer</li>
+          <!-- Remington M95 -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.275, 0.100, -0.073)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_LeverActionShotgun</li>
+          <!-- Winchester M1887 (sawed-off) -->
+        </ThingTargets>
+      </li>
     </WeaponCompLoader>
   </WHands.ClutterHandsTDef>
 </Defs>

--- a/1.4/Defs/Mods/CEGuns.xml
+++ b/1.4/Defs/Mods/CEGuns.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_CombatExtendedGuns</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.247, 0.100, -0.050)</MainHand>
+              <SecHand>(0.200, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeAMR</li> <!-- A-12 charge anti-materiel rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, 0.023)</MainHand>
+              <SecHand>(0.170, -0.100, 0.069)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_AKM</li> <!-- AKM -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.142, 0.100, -0.018)</MainHand>
+              <SecHand>(0.225, -0.100, -0.022)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_Crossbow</li> <!-- crossbow -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.279, 0.100, 0.005)</MainHand>
+              <SecHand>(0.202, -0.100, 0.019)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_FlintlockMusket</li> <!-- flintlock musket -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.146, 0.100, -0.027)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_FlintlockPistol</li> <!-- flintlock pistol -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.188, 0.100, -0.018)</MainHand>
+              <SecHand>(0.179, -0.100, 0.014)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_FNFAL</li> <!-- FN FAL -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, -0.073)</MainHand>
+              <SecHand>(0.106, -0.100, -0.041)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_HecateTwo</li> <!-- Hecate II -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, -0.091)</MainHand>
+              <SecHand>(0.124, -0.100, -0.078)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeLMG</li> <!-- L-8 charge LMG -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.188, 0.100, -0.050)</MainHand>
+              <SecHand>(0.133, -0.100, -0.018)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MSixty</li> <!-- M60E6 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.160, 0.100, -0.036)</MainHand>
+              <SecHand>(0.111, -0.100, -0.013)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MTwoFourNine</li> <!-- M249 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.201, 0.100, -0.114)</MainHand>
+              <SecHand>(0.239, -0.100, -0.128)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_MilkorMGL</li> <!-- Milkor MGL -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.114, 0.100, -0.091)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargePistol</li> <!-- P-10 charge pistol -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.197, 0.100, -0.041)</MainHand>
+              <SecHand>(0.138, -0.100, -0.027)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_PKM</li> <!-- PKM -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.311, 0.100, 0.037)</MainHand>
+              <SecHand>(0.166, -0.100, 0.028)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_PTRS</li> <!-- PTRS-41 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.247, 0.100, -0.082)</MainHand>
+              <SecHand>(0.138, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeSniperRifle</li> <!-- R-8 charge sniper rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.325, 0.100, -0.096)</MainHand>
+              <SecHand>(0.088, -0.100, -0.059)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_Flamethrower</li> <!-- RM2 Flamethrower -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, -0.013)</MainHand>
+              <SecHand>(0.083, -0.100, 0.033)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_RPD</li> <!-- RPD -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.211, 0.100, -0.050)</MainHand>
+              <SecHand>(0.078, -0.100, -0.082)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_RPGSeven</li> <!-- RPG-7 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.123, 0.100, -0.018)</MainHand>
+              <ThingTargets>
+                 <li>CE_Gun_SWGovernor</li> <!-- S&W Governor -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.169, 0.100, -0.027)</MainHand>
+              <SecHand>(0.317, -0.100, -0.013)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeShotgun</li> <!-- S-12 charge shotgun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.073, 0.100, -0.096)</MainHand>
+              <SecHand>(0.133, -0.100, -0.114)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_ChargeSMG</li> <!-- S-6 charge SMG -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, -0.078)</MainHand>
+              <SecHand>(0.120, -0.100, -0.036)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_SVD</li> <!-- SVD -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.018)</MainHand>
+              <SecHand>(0.166, -0.100, 0.042)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_USASTwelve</li> <!-- USAS-12 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.013)</MainHand>
+              <SecHand>(0.065, -0.100, -0.009)</SecHand>
+              <ThingTargets>
+                 <li>CE_Gun_WinchesterNintyFour</li> <!-- Winchester 94 -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.4/Defs/Mods/CEGuns.xml
+++ b/1.4/Defs/Mods/CEGuns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="CETeam.CombatExtendedGuns">
      <defName>ClutterHandsSettings_CombatExtendedGuns</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.4/Defs/Mods/CETeam.CombatExtended.xml
+++ b/1.4/Defs/Mods/CETeam.CombatExtended.xml
@@ -49,6 +49,28 @@
           <!-- stick bomb -->
         </ThingTargets>
       </li>
+      <li>
+        <MainHand>(-0.004, 0.100, -0.078)</MainHand>
+        <ThingTargets>
+          <li>Weapon_GrenadeConcussion</li>
+          <!-- concussion grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.273, 0.100, -0.050)</MainHand>
+        <SecHand>(0.200, -0.100, -0.050)</SecHand>
+        <ThingTargets>
+          <li>CE_DisposableRocketLauncher</li>
+          <!-- M72 LAW -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.140, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>CE_FlareGun</li>
+          <!-- flare gun -->
+        </ThingTargets>
+      </li>
     </WeaponCompLoader>
   </WHands.ClutterHandsTDef>
 </Defs>

--- a/1.4/Defs/Mods/SparklingWorldsFullMod.xml
+++ b/1.4/Defs/Mods/SparklingWorldsFullMod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="Albion.SparklingWorlds.Full">
      <defName>ClutterHandsSettings_SparklingWorldsFullMod</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.4/Defs/Mods/SparklingWorldsFullMod.xml
+++ b/1.4/Defs/Mods/SparklingWorldsFullMod.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_SparklingWorldsFullMod</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(0.010, 0.100, -0.073)</MainHand>
+              <SecHand>(0.340, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>Gun_BulletstormSW</li> <!-- bulletstorm -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.000, 0.000, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>BurnStickSW</li> <!-- burn gauntlet -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.142, 0.100, -0.068)</MainHand>
+              <SecHand>(0.244, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>Gun_RailgunSW</li> <!-- gauss lance -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.087, 0.100, -0.050)</MainHand>
+              <SecHand>(0.234, -0.100, -0.027)</SecHand>
+              <ThingTargets>
+                 <li>Gun_GaussrifleSW</li> <!-- gauss rifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.156, 0.100, -0.036)</MainHand>
+              <ThingTargets>
+                 <li>Gun_PainGunSW</li> <!-- pain gun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.293, 0.100, -0.027)</MainHand>
+              <ThingTargets>
+                 <li>PainStickSW</li> <!-- pain stick -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.100, 0.100, -0.110)</MainHand>
+              <SecHand>(0.225, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>Gun_PlasmaGunSW</li> <!-- plasma gun -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.4/Defs/Mods/VFEC.xml
+++ b/1.4/Defs/Mods/VFEC.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="OskarPotocki.VFE.Classical">
      <defName>ClutterHandsSettings_VanillaFactionsExpandedClassical</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.4/Defs/Mods/VFEC.xml
+++ b/1.4/Defs/Mods/VFEC.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedClassical</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.169, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_MeleeWeapon_Dagger</li> <!-- dagger -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.385, 0.100, -0.013)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_Javelin</li> <!-- javelin -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.334, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_MeleeWeapon_Spatha</li> <!-- spatha -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.000, 0.000, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VFEC_Weapon_Scorpion</li> <!-- scorpion -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.4/Defs/Mods/VFEP.xml
+++ b/1.4/Defs/Mods/VFEP.xml
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedPirates</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.266, 0.100, -0.105)</MainHand>
+              <SecHand>(0.046, -0.100, -0.169)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Autorifle</li> <!-- warcasket autorifle -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.321, 0.100, -0.357)</MainHand>
+              <SecHand>(-0.229, -0.100, -0.270)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_Broadsword</li> <!-- warcasket broadsword -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.371, 0.100, 0.010)</MainHand>
+              <SecHand>(0.156, -0.100, -0.165)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_ChargeBlaster</li> <!-- warcasket charge blaster -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.275, 0.100, 0.133)</MainHand>
+              <SecHand>(0.216, -0.100, -0.123)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_ChargeLance</li> <!-- warcasket charge lance -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.009)</MainHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_CombatKnife</li> <!-- warcasket combat knife -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.311, 0.100, 0.088)</MainHand>
+              <SecHand>(0.014, -0.100, 0.166)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_CryptoCannon</li> <!-- warcasket crypto cannon -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.302, 0.100, -0.105)</MainHand>
+              <SecHand>(-0.027, -0.100, 0.083)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_FoldingGun</li> <!-- warcasket folding gun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.307, 0.100, -0.293)</MainHand>
+              <SecHand>(-0.091, -0.100, -0.087)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketMeleeWeapon_GravityHammer</li> <!-- warcasket gravity hammer -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.362, 0.100, -0.215)</MainHand>
+              <SecHand>(0.124, -0.100, -0.146)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_GrenadeLauncher</li> <!-- warcasket grenade launcher -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.288, 0.100, -0.078)</MainHand>
+              <SecHand>(0.106, -0.100, 0.166)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_HandheldCannon</li> <!-- warcasket handheld cannon -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.325, 0.100, 0.179)</MainHand>
+              <SecHand>(0.042, -0.100, 0.184)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_HeavyFlamer</li> <!-- warcasket heavy flamer -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.348, 0.100, 0.198)</MainHand>
+              <SecHand>(-0.087, -0.100, 0.170)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Minigun</li> <!-- warcasket minigun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.289, 0.100, -0.298)</MainHand>
+              <SecHand>(-0.078, -0.100, 0.088)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Railgun</li> <!-- warcasket railgun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.238, 0.100, -0.078)</MainHand>
+              <SecHand>(0.065, -0.100, -0.123)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_Slugthrower</li> <!-- warcasket slugthrower -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.256, 0.100, -0.087)</MainHand>
+              <SecHand>(0.042, -0.100, -0.050)</SecHand>
+              <ThingTargets>
+                 <li>VFEP_WarcasketGun_UraniumSlugRifle</li> <!-- warcasket uranium slug rifle -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.4/Defs/Mods/VFEP.xml
+++ b/1.4/Defs/Mods/VFEP.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="OskarPotocki.VFE.Pirates">
      <defName>ClutterHandsSettings_VanillaFactionsExpandedPirates</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.4/Defs/Mods/VFES.xml
+++ b/1.4/Defs/Mods/VFES.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaFactionsExpandedSettlers</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.261, 0.100, -0.321)</MainHand>
+              <ThingTargets>
+                 <li>VFES_Gun_DoubleActionRevolver</li> <!-- Colt SAA -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.091, 0.100, -0.082)</MainHand>
+              <SecHand>(0.092, 0.100, -0.128)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Weapon_GrenadeDynamite</li> <!-- dynamite -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.279, 0.100, -0.045)</MainHand>
+              <SecHand>(0.267, -0.100, -0.018)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Gun_HuntingRifle</li> <!-- M1903 Springfield -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.174, 0.100, -0.128)</MainHand>
+              <ThingTargets>
+                 <li>VFES_Tomahawk</li> <!-- tomahawk -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.220, 0.100, -0.055)</MainHand>
+              <SecHand>(0.078, -0.100, -0.036)</SecHand>
+              <ThingTargets>
+                 <li>VFES_Gun_DoubleBarreledShotgun</li> <!-- Winchester M21 -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.4/Defs/Mods/VPE.xml
+++ b/1.4/Defs/Mods/VPE.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef>
+     <defName>ClutterHandsSettings_VanillaPsycastsExpanded</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.188, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexDagger</li> <!-- eltex dagger -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.151, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexMace</li> <!-- eltex mace -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.261, 0.100, 0.000)</MainHand>
+              <ThingTargets>
+                 <li>VPE_MeleeWeapon_EltexSword</li> <!-- eltex sword -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.4/Defs/Mods/VPE.xml
+++ b/1.4/Defs/Mods/VPE.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <WHands.ClutterHandsTDef>
+  <WHands.ClutterHandsTDef MayRequire="VanillaExpanded.VPsycastsE">
      <defName>ClutterHandsSettings_VanillaPsycastsExpanded</defName>
       <label>Weapon hand settings</label>
       <thingClass>Thing</thingClass>

--- a/1.4/Defs/Mods/VTE.xml
+++ b/1.4/Defs/Mods/VTE.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="VanillaExpanded.VTEXE">
+     <defName>ClutterHandsSettings_Core_VanillaTexturesExpanded</defName>
+      <label>Weapon hand settings</label>
+      <thingClass>Thing</thingClass>
+      <WeaponCompLoader>
+          <li>
+              <MainHand>(-0.243, 0.100, 0.014)</MainHand>
+              <SecHand>(0.248, -0.100, 0.042)</SecHand>
+              <ThingTargets>
+                 <li>Gun_BoltActionRifle</li> <!-- Lee-Enfield -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.183, 0.100, -0.055)</MainHand>
+              <SecHand>(0.202, -0.100, 0.005)</SecHand>
+              <ThingTargets>
+                 <li>Gun_AssaultRifle</li> <!-- M16A3 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(0.120, 0.100, -0.041)</MainHand>
+              <ThingTargets>
+                 <li>Gun_MachinePistol</li> <!-- MAC-10 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.105, 0.100, 0.022)</MainHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Mace</li> <!-- mace -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.444, 0.100, -0.082)</MainHand>
+              <SecHand>(-0.114, -0.100, 0.019)</SecHand>
+              <ThingTargets>
+                 <li>Gun_Minigun</li> <!-- minigun -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.156, 0.100, -0.021)</MainHand>
+              <SecHand>(0.200, -0.100, 0.028)</SecHand>
+              <ThingTargets>
+                 <li>Gun_ChainShotgun</li> <!-- Saiga 12K -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.266, 0.100, -0.247)</MainHand>
+              <SecHand>(-0.009, -0.100, 0.000)</SecHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Spear</li> <!-- spear -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.055, 0.100, -0.174)</MainHand>
+              <SecHand>(0.253, -0.100, -0.142)</SecHand>
+              <ThingTargets>
+                 <li>Gun_HeavySMG</li> <!-- UMP45 -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.220, 0.100, -0.059)</MainHand>
+              <SecHand>(0.106, -0.100, 0.253)</SecHand>
+              <ThingTargets>
+                 <li>WoodLog</li> <!-- wood -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.215, 0.100, 0.005)</MainHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_Ikwa</li> <!-- ikwa -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.068, 0.100, -0.082)</MainHand>
+              <ThingTargets>
+                 <li>Weapon_GrenadeEMP</li> <!-- EMP grenade -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.041, 0.100, -0.050)</MainHand>
+              <ThingTargets>
+                 <li>Weapon_GrenadeFrag</li> <!-- frag grenade -->
+              </ThingTargets>
+          </li>
+          <li>
+              <MainHand>(-0.144, 0.100, 0.000)</MainHand>
+              <SecHand>(0.000, -0.100, 0.000)</SecHand>
+              <ThingTargets>
+                 <li>MeleeWeapon_BreachAxe</li> <!-- breach axe -->
+              </ThingTargets>
+          </li>
+      </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.4/Defs/Mods/VWEFT.xml
+++ b/1.4/Defs/Mods/VWEFT.xml
@@ -42,6 +42,43 @@
           <!-- volcanic pistol -->
         </ThingTargets>
       </li>
+      <li>
+        <MainHand>(-0.215, 0.100, -0.032)</MainHand>
+        <SecHand>(0.230, -0.100, 0.005)</SecHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_GaussRepeater</li>
+          <!-- gauss repeater -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.247, 0.100, -0.050)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_GaussRevolver</li>
+          <!-- gauss revolver -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.403, 0.100, 0.051)</MainHand>
+        <SecHand>(-0.156, -0.100, -0.233)</SecHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_HandheldGatlingGun</li>
+          <!-- handheld gatling gun -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.178, 0.100, -0.078)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_Derringer</li>
+          <!-- Remington M95 -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.275, 0.100, -0.073)</MainHand>
+        <ThingTargets>
+          <li>VWEFT_Gun_LeverActionShotgun</li>
+          <!-- Winchester M1887 (sawed-off) -->
+        </ThingTargets>
+      </li>
     </WeaponCompLoader>
   </WHands.ClutterHandsTDef>
 </Defs>


### PR DESCRIPTION
- Combat Extended Guns
- Missing concussion grenade, rocket launcher, flare gun from base Combat Extended
- Sparkling Worlds - Full Mod
- Vanilla Factions Expanded - Settlers
- Vanilla Factions Expanded - Classical
- Vanilla Factions Expanded - Pirates
- Vanilla Psycasts Expanded
- Missing gauss repeater, gauss revolver, handheld gatling gun, derringer, lever action shotgun from Vanilla Weapons Expanded - Frontier
- Fixed hand positions for Vanilla Textures Expanded's core gun retextures (I think I did this right? check [VTE.xml](https://github.com/emipa606/ShowMeYourHands/pull/4/commits/f7508b3a2bc27645a7627e30ac328201bbde4959#diff-4f16382f7d4da9fda2c99cd278fb071b6c34664acb23c935779b389f189ade97))