### PR TITLE
Hand position corrections & additions

### DIFF
--- a/1.1/Defs/Mods/CEGuns.xml
+++ b/1.1/Defs/Mods/CEGuns.xml
@@ -30,6 +30,14 @@
         </ThingTargets>
       </li>
       <li>
+        <MainHand>(-0.165, 0.100, -0.087)</MainHand>
+        <SecHand>(0.308, -0.100, -0.050)</SecHand>
+        <ThingTargets>
+          <li>CE_Gun_FlintlockBlunderbuss</li>
+          <!-- flintlock blunderbuss -->
+        </ThingTargets>
+      </li>
+      <li>
         <MainHand>(-0.279, 0.100, 0.005)</MainHand>
         <SecHand>(0.202, -0.100, 0.019)</SecHand>
         <ThingTargets>

--- a/1.1/Defs/Mods/CETeam.CombatExtended.xml
+++ b/1.1/Defs/Mods/CETeam.CombatExtended.xml
@@ -6,8 +6,7 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.129, 0.100, -0.050)</MainHand>
-        <SecHand>(-0.046, -0.100, 0.128)</SecHand>
+        <MainHand>(-0.064, 0.100, -0.050)</MainHand>
         <ThingTargets>
           <li>Gun_BinocularsRadio</li>
           <!-- binoculars -->
@@ -69,6 +68,13 @@
         <ThingTargets>
           <li>CE_FlareGun</li>
           <!-- flare gun -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.362, 0.100, -0.059)</MainHand>
+        <ThingTargets>
+          <li>Pila</li>
+          <!-- javelins -->
         </ThingTargets>
       </li>
     </WeaponCompLoader>

--- a/1.1/Defs/Mods/ReinforcedMechanoids2.xml
+++ b/1.1/Defs/Mods/ReinforcedMechanoids2.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="hlx.reinforcedmechanoids2">
+    <defName>ClutterHandsSettings_ReinforcedMechanoid2</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.252, 0.100, -0.073)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ARCPistol</li>
+          <!-- ARC pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.344, 0.100, -0.082)</MainHand>
+        <SecHand>(0.133, -0.100, -0.110)</SecHand>
+        <ThingTargets>
+          <li>RM_ARCRifle</li>
+          <!-- ARC rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.270, 0.100, 0.023)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargeLancePistol</li>
+          <!-- charge lance pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.266, 0.100, -0.137)</MainHand>
+        <SecHand>(0.299, -0.100, -0.082)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargeLanceRifle</li>
+          <!-- charge lance rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.289, 0.100, -0.018)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargePistol</li>
+          <!-- charge pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.215, 0.100, -0.073)</MainHand>
+        <SecHand>(0.092, 0.100, -0.220)</SecHand>
+        <ThingTargets>
+          <li>RM_Weapon_GrenadePlasmaImmolator</li>
+          <!-- immolator grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.064, 0.100, 0.111)</MainHand>
+        <SecHand>(0.156, 0.100, 0.000)</SecHand>
+        <ThingTargets>
+          <li>RM_Weapon_GrenadePlasmaImmolator_V</li>
+          <!-- immolator grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.422, 0.100, -0.050)</MainHand>
+        <SecHand>(0.175, -0.100, 0.202)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_InfernoLauncher</li>
+          <!-- inferno launcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.169, 0.100, -0.160)</MainHand>
+        <SecHand>(0.152, -0.100, -0.114)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_InfernoRifle</li>
+          <!-- inferno rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.321, 0.100, -0.050)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ShardLance</li>
+          <!-- shard lance -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.247, 0.100, -0.009)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ShardLauncher</li>
+          <!-- shard launcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.192, 0.100, -0.206)</MainHand>
+        <ThingTargets>
+          <li>RM_MeleeWeapon_PlasmaBane</li>
+          <!-- plasma bane -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.211, 0.100, -0.206)</MainHand>
+        <ThingTargets>
+          <li>RM_MeleeWeapon_PlasmaSword</li>
+          <!-- plasma sword -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.1/Defs/Mods/TurretCollection.xml
+++ b/1.1/Defs/Mods/TurretCollection.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="eatkenny.leafzxg.dws.turretcollection">
+    <defName>ClutterHandsSettings_TurretCollectionUnofficial</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.156, 0.100, -0.091)</MainHand>
+        <SecHand>(0.225, -0.100, -0.174)</SecHand>
+        <ThingTargets>
+          <li>Gun_AATWS_TC</li>
+          <!-- AATWS -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.1/Defs/Mods/UltratechAlteredCarbon.xml
+++ b/1.1/Defs/Mods/UltratechAlteredCarbon.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="hlx.ultratechalteredcarbon">
+    <defName>ClutterHandsSettings_AlteredCarbonUltratechUnleashed</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.059, 0.100, -0.128)</MainHand>
+        <ThingTargets>
+          <li>AC_Gun_Autorevolver</li>
+          <!-- autorevolver -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.1/Defs/Mods/VFEE.xml
+++ b/1.1/Defs/Mods/VFEE.xml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="oskarpotocki.vfe.empire">
+    <defName>ClutterHandsSettings_VanillaFactionsExpandedEmpire</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.206, 0.100, -0.105)</MainHand>
+        <SecHand>(0.189, -0.100, -0.073)</SecHand>
+        <ThingTargets>
+          <li>VFEE_Gun_ChargeThumper</li>
+          <!-- charge thumper -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.261, 0.100, -0.087)</MainHand>
+        <SecHand>(0.101, -0.100, -0.082)</SecHand>
+        <ThingTargets>
+          <li>VEE_Gun_Fletcher</li>
+          <!-- fletcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.183, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>VFEE_MeleeWeapon_ToxbladeBladelink</li>
+          <!-- persona toxblade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.188, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>VFEE_MeleeWeapon_Toxblade</li>
+          <!-- toxblade -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.1/Defs/Mods/VWEFT.xml
+++ b/1.1/Defs/Mods/VWEFT.xml
@@ -59,7 +59,7 @@
       </li>
       <li>
         <MainHand>(-0.403, 0.100, 0.051)</MainHand>
-        <SecHand>(-0.156, -0.100, -0.233)</SecHand>
+        <SecHand>(-0.119, -0.100, 0.138)</SecHand>
         <ThingTargets>
           <li>VWEFT_Gun_HandheldGatlingGun</li>
           <!-- handheld gatling gun -->

--- a/1.1/Defs/Mods/VanillaExpanded.VWE.xml
+++ b/1.1/Defs/Mods/VanillaExpanded.VWE.xml
@@ -6,8 +6,8 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.194, 0.100, 0.189)</MainHand>
-        <SecHand>(0.023, -0.100, -0.270)</SecHand>
+        <MainHand>(-0.224, 0.100, 0.189)</MainHand>
+        <SecHand>(0.019, -0.100, -0.334)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_FireExtinguisher</li>
           <!-- fire extinguisher -->
@@ -29,8 +29,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(0.098, 0.100, -0.203)</MainHand>
-        <SecHand>(0.330, -0.100, -0.119)</SecHand>
+        <MainHand>(0.051, 0.100, -0.119)</MainHand>
+        <SecHand>(0.244, -0.100, -0.119)</SecHand>
         <ThingTargets>
           <li>Gun_DoomsdayRocket</li>
           <!-- doomsday rocket launcher -->
@@ -265,8 +265,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(0.014, 0.100, -0.180)</MainHand>
-        <SecHand>(0.204, -0.100, 0.127)</SecHand>
+        <MainHand>(-0.036, 0.100, -0.146)</MainHand>
+        <SecHand>(0.244, -0.100, -0.128)</SecHand>
         <ThingTargets>
           <li>Gun_TripleRocket</li>
           <!-- triple rocket launcher -->
@@ -281,14 +281,15 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.025, 0.100, -0.050)</MainHand>
+        <MainHand>(-0.252, 0.100, -0.013)</MainHand>
+        <SecHand>(0.184, 0.100, -0.247)</SecHand>
         <ThingTargets>
           <li>VWE_Throwing_Rocks</li>
           <!-- throwing rocks -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.052, 0.100, -0.215)</MainHand>
+        <MainHand>(-0.004, 0.100, -0.156)</MainHand>
         <ThingTargets>
           <li>VWE_Throwing_Knives</li>
           <!-- throwing knives -->
@@ -327,7 +328,6 @@
       </li>
       <li>
         <MainHand>(-0.211, 0.100, -0.050)</MainHand>
-        <SecHand>(0.136, -0.100, -0.022)</SecHand>
         <ThingTargets>
           <li>VWE_SawedOffShotgun</li>
           <!-- sawed-off Shotgun -->
@@ -365,7 +365,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.324, 0.100, 0.000)</MainHand>
+        <MainHand>(-0.302, 0.100, 0.000)</MainHand>
+        <SecHand>(-0.105, -0.100, 0.000)</SecHand>
         <ThingTargets>
           <li>VWE_MeleeWeapon_Shovel</li>
           <!-- shovel -->

--- a/1.1/Defs/Mods/VanillaExpanded.VWEHW.xml
+++ b/1.1/Defs/Mods/VanillaExpanded.VWEHW.xml
@@ -6,40 +6,40 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.128, 0.100, 0.129)</MainHand>
-        <SecHand>(-0.023, -0.100, 0.092)</SecHand>
+        <MainHand>(-0.367, 0.100, 0.092)</MainHand>
+        <SecHand>(-0.041, -0.100, 0.143)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_Autocannon</li>
           <!-- autocannon -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.220, 0.100, 0.189)</MainHand>
-        <SecHand>(-0.071, -0.100, 0.161)</SecHand>
+        <MainHand>(-0.371, 0.100, -0.022)</MainHand>
+        <SecHand>(-0.123, -0.100, 0.225)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_HandheldMortar</li>
           <!-- handheld mortar -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.059, 0.100, 0.065)</MainHand>
-        <SecHand>(0.072, -0.100, 0.005)</SecHand>
+        <MainHand>(-0.412, 0.100, 0.000)</MainHand>
+        <SecHand>(0.023, -0.100, 0.083)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_HeavyFlamer</li>
           <!-- heavy flamer -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.036, 0.100, 0.147)</MainHand>
-        <SecHand>(0.129, -0.100, 0.069)</SecHand>
+        <MainHand>(-0.357, 0.100, 0.060)</MainHand>
+        <SecHand>(0.056, -0.100, 0.138)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_SwarmMissileLauncher</li>
           <!-- swarm missile launcher -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.283, 0.100, -0.206)</MainHand>
-        <SecHand>(0.088, -0.100, -0.100)</SecHand>
+        <MainHand>(-0.412, 0.100, 0.101)</MainHand>
+        <SecHand>(-0.215, -0.100, -0.243)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_UraniumSlugRifle</li>
           <!-- uranium slug rifle -->

--- a/1.1/Defs/Mods/VanillaExpanded.VWEQ.xml
+++ b/1.1/Defs/Mods/VanillaExpanded.VWEQ.xml
@@ -13,7 +13,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.190, 0.100, -0.078)</MainHand>
+        <MainHand>(-0.178, 0.100, -0.078)</MainHand>
         <SecHand>(0.175, -0.100, -0.018)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_BullpupDMR</li>
@@ -21,8 +21,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.219, 0.100, -0.096)</MainHand>
-        <SecHand>(-0.033, -0.100, -0.050)</SecHand>
+        <MainHand>(-0.027, 0.100, -0.114)</MainHand>
+        <SecHand>(0.234, -0.100, -0.045)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_BullpupRifle</li>
           <!-- bullpup rifle -->
@@ -30,7 +30,7 @@
       </li>
       <li>
         <MainHand>(-0.026, 0.100, -0.110)</MainHand>
-        <SecHand>(0.168, -0.100, -0.133)</SecHand>
+        <SecHand>(0.267, -0.100, -0.151)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_PDW</li>
           <!-- PDW -->

--- a/1.1/Defs/Mods/VanillaExpanded.VWETB.xml
+++ b/1.1/Defs/Mods/VanillaExpanded.VWETB.xml
@@ -36,7 +36,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.045, 0.100, -0.239)</MainHand>
+        <MainHand>(-0.018, 0.100, -0.169)</MainHand>
         <ThingTargets>
           <li>VWE_Throwing_Shards</li>
           <!-- throwing shards -->
@@ -50,8 +50,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.253, -0.100, -0.050)</MainHand>
-        <SecHand>(0.269, 0.100, -0.050)</SecHand>
+        <MainHand>(-0.027, 0.100, -0.050)</MainHand>
         <ThingTargets>
           <li>VWE_Weapon_FireBomb</li>
           <!-- fire bombs -->

--- a/1.1/Defs/ThingDefs/Core.xml
+++ b/1.1/Defs/ThingDefs/Core.xml
@@ -302,6 +302,36 @@
           <li>MeleeWeapon_Zeushammer</li>
         </ThingTargets>
       </li>
+      <li>
+        <MainHand>(-0.144, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>MeleeWeapon_BreachAxe</li>
+          <!-- breach axe -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(0.164, 0.100, 0.000)</MainHand>
+        <SecHand>(-0.092, -0.100, 0.000)</SecHand>
+        <ThingTargets>
+          <li>Flamebow</li>
+          <!-- flamebow -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.041, 0.100, -0.100)</MainHand>
+        <ThingTargets>
+          <li>Weapon_GrenadeTox</li>
+          <!-- tox grenades -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.142, 0.100, -0.179)</MainHand>
+        <SecHand>(0.163, -0.100, -0.169)</SecHand>
+        <ThingTargets>
+          <li>Gun_ToxbombLauncher</li>
+          <!-- toxbomb launcher -->
+        </ThingTargets>
+      </li>
     </WeaponCompLoader>
   </WHands.ClutterHandsTDef>
 </Defs>

--- a/1.2/Defs/Mods/CEGuns.xml
+++ b/1.2/Defs/Mods/CEGuns.xml
@@ -30,6 +30,14 @@
         </ThingTargets>
       </li>
       <li>
+        <MainHand>(-0.165, 0.100, -0.087)</MainHand>
+        <SecHand>(0.308, -0.100, -0.050)</SecHand>
+        <ThingTargets>
+          <li>CE_Gun_FlintlockBlunderbuss</li>
+          <!-- flintlock blunderbuss -->
+        </ThingTargets>
+      </li>
+      <li>
         <MainHand>(-0.279, 0.100, 0.005)</MainHand>
         <SecHand>(0.202, -0.100, 0.019)</SecHand>
         <ThingTargets>

--- a/1.2/Defs/Mods/CETeam.CombatExtended.xml
+++ b/1.2/Defs/Mods/CETeam.CombatExtended.xml
@@ -6,8 +6,7 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.129, 0.100, -0.050)</MainHand>
-        <SecHand>(-0.046, -0.100, 0.128)</SecHand>
+        <MainHand>(-0.064, 0.100, -0.050)</MainHand>
         <ThingTargets>
           <li>Gun_BinocularsRadio</li>
           <!-- binoculars -->
@@ -69,6 +68,13 @@
         <ThingTargets>
           <li>CE_FlareGun</li>
           <!-- flare gun -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.362, 0.100, -0.059)</MainHand>
+        <ThingTargets>
+          <li>Pila</li>
+          <!-- javelins -->
         </ThingTargets>
       </li>
     </WeaponCompLoader>

--- a/1.2/Defs/Mods/ReinforcedMechanoids2.xml
+++ b/1.2/Defs/Mods/ReinforcedMechanoids2.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="hlx.reinforcedmechanoids2">
+    <defName>ClutterHandsSettings_ReinforcedMechanoid2</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.252, 0.100, -0.073)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ARCPistol</li>
+          <!-- ARC pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.344, 0.100, -0.082)</MainHand>
+        <SecHand>(0.133, -0.100, -0.110)</SecHand>
+        <ThingTargets>
+          <li>RM_ARCRifle</li>
+          <!-- ARC rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.270, 0.100, 0.023)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargeLancePistol</li>
+          <!-- charge lance pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.266, 0.100, -0.137)</MainHand>
+        <SecHand>(0.299, -0.100, -0.082)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargeLanceRifle</li>
+          <!-- charge lance rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.289, 0.100, -0.018)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargePistol</li>
+          <!-- charge pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.215, 0.100, -0.073)</MainHand>
+        <SecHand>(0.092, 0.100, -0.220)</SecHand>
+        <ThingTargets>
+          <li>RM_Weapon_GrenadePlasmaImmolator</li>
+          <!-- immolator grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.064, 0.100, 0.111)</MainHand>
+        <SecHand>(0.156, 0.100, 0.000)</SecHand>
+        <ThingTargets>
+          <li>RM_Weapon_GrenadePlasmaImmolator_V</li>
+          <!-- immolator grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.422, 0.100, -0.050)</MainHand>
+        <SecHand>(0.175, -0.100, 0.202)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_InfernoLauncher</li>
+          <!-- inferno launcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.169, 0.100, -0.160)</MainHand>
+        <SecHand>(0.152, -0.100, -0.114)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_InfernoRifle</li>
+          <!-- inferno rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.321, 0.100, -0.050)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ShardLance</li>
+          <!-- shard lance -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.247, 0.100, -0.009)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ShardLauncher</li>
+          <!-- shard launcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.192, 0.100, -0.206)</MainHand>
+        <ThingTargets>
+          <li>RM_MeleeWeapon_PlasmaBane</li>
+          <!-- plasma bane -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.211, 0.100, -0.206)</MainHand>
+        <ThingTargets>
+          <li>RM_MeleeWeapon_PlasmaSword</li>
+          <!-- plasma sword -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.2/Defs/Mods/TurretCollection.xml
+++ b/1.2/Defs/Mods/TurretCollection.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="eatkenny.leafzxg.dws.turretcollection">
+    <defName>ClutterHandsSettings_TurretCollectionUnofficial</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.156, 0.100, -0.091)</MainHand>
+        <SecHand>(0.225, -0.100, -0.174)</SecHand>
+        <ThingTargets>
+          <li>Gun_AATWS_TC</li>
+          <!-- AATWS -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.2/Defs/Mods/UltratechAlteredCarbon.xml
+++ b/1.2/Defs/Mods/UltratechAlteredCarbon.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="hlx.ultratechalteredcarbon">
+    <defName>ClutterHandsSettings_AlteredCarbonUltratechUnleashed</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.059, 0.100, -0.128)</MainHand>
+        <ThingTargets>
+          <li>AC_Gun_Autorevolver</li>
+          <!-- autorevolver -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.2/Defs/Mods/VFEE.xml
+++ b/1.2/Defs/Mods/VFEE.xml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="oskarpotocki.vfe.empire">
+    <defName>ClutterHandsSettings_VanillaFactionsExpandedEmpire</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.206, 0.100, -0.105)</MainHand>
+        <SecHand>(0.189, -0.100, -0.073)</SecHand>
+        <ThingTargets>
+          <li>VFEE_Gun_ChargeThumper</li>
+          <!-- charge thumper -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.261, 0.100, -0.087)</MainHand>
+        <SecHand>(0.101, -0.100, -0.082)</SecHand>
+        <ThingTargets>
+          <li>VEE_Gun_Fletcher</li>
+          <!-- fletcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.183, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>VFEE_MeleeWeapon_ToxbladeBladelink</li>
+          <!-- persona toxblade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.188, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>VFEE_MeleeWeapon_Toxblade</li>
+          <!-- toxblade -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.2/Defs/Mods/VWEFT.xml
+++ b/1.2/Defs/Mods/VWEFT.xml
@@ -59,7 +59,7 @@
       </li>
       <li>
         <MainHand>(-0.403, 0.100, 0.051)</MainHand>
-        <SecHand>(-0.156, -0.100, -0.233)</SecHand>
+        <SecHand>(-0.119, -0.100, 0.138)</SecHand>
         <ThingTargets>
           <li>VWEFT_Gun_HandheldGatlingGun</li>
           <!-- handheld gatling gun -->

--- a/1.2/Defs/Mods/VanillaExpanded.VWE.xml
+++ b/1.2/Defs/Mods/VanillaExpanded.VWE.xml
@@ -6,8 +6,8 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.194, 0.100, 0.189)</MainHand>
-        <SecHand>(0.023, -0.100, -0.270)</SecHand>
+        <MainHand>(-0.224, 0.100, 0.189)</MainHand>
+        <SecHand>(0.019, -0.100, -0.334)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_FireExtinguisher</li>
           <!-- fire extinguisher -->
@@ -29,8 +29,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(0.098, 0.100, -0.203)</MainHand>
-        <SecHand>(0.330, -0.100, -0.119)</SecHand>
+        <MainHand>(0.051, 0.100, -0.119)</MainHand>
+        <SecHand>(0.244, -0.100, -0.119)</SecHand>
         <ThingTargets>
           <li>Gun_DoomsdayRocket</li>
           <!-- doomsday rocket launcher -->
@@ -265,8 +265,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(0.014, 0.100, -0.180)</MainHand>
-        <SecHand>(0.204, -0.100, 0.127)</SecHand>
+        <MainHand>(-0.036, 0.100, -0.146)</MainHand>
+        <SecHand>(0.244, -0.100, -0.128)</SecHand>
         <ThingTargets>
           <li>Gun_TripleRocket</li>
           <!-- triple rocket launcher -->
@@ -281,14 +281,15 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.025, 0.100, -0.050)</MainHand>
+        <MainHand>(-0.252, 0.100, -0.013)</MainHand>
+        <SecHand>(0.184, 0.100, -0.247)</SecHand>
         <ThingTargets>
           <li>VWE_Throwing_Rocks</li>
           <!-- throwing rocks -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.052, 0.100, -0.215)</MainHand>
+        <MainHand>(-0.004, 0.100, -0.156)</MainHand>
         <ThingTargets>
           <li>VWE_Throwing_Knives</li>
           <!-- throwing knives -->
@@ -327,7 +328,6 @@
       </li>
       <li>
         <MainHand>(-0.211, 0.100, -0.050)</MainHand>
-        <SecHand>(0.136, -0.100, -0.022)</SecHand>
         <ThingTargets>
           <li>VWE_SawedOffShotgun</li>
           <!-- sawed-off Shotgun -->
@@ -365,7 +365,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.324, 0.100, 0.000)</MainHand>
+        <MainHand>(-0.302, 0.100, 0.000)</MainHand>
+        <SecHand>(-0.105, -0.100, 0.000)</SecHand>
         <ThingTargets>
           <li>VWE_MeleeWeapon_Shovel</li>
           <!-- shovel -->

--- a/1.2/Defs/Mods/VanillaExpanded.VWEHW.xml
+++ b/1.2/Defs/Mods/VanillaExpanded.VWEHW.xml
@@ -6,40 +6,40 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.128, 0.100, 0.129)</MainHand>
-        <SecHand>(-0.023, -0.100, 0.092)</SecHand>
+        <MainHand>(-0.367, 0.100, 0.092)</MainHand>
+        <SecHand>(-0.041, -0.100, 0.143)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_Autocannon</li>
           <!-- autocannon -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.220, 0.100, 0.189)</MainHand>
-        <SecHand>(-0.071, -0.100, 0.161)</SecHand>
+        <MainHand>(-0.371, 0.100, -0.022)</MainHand>
+        <SecHand>(-0.123, -0.100, 0.225)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_HandheldMortar</li>
           <!-- handheld mortar -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.059, 0.100, 0.065)</MainHand>
-        <SecHand>(0.072, -0.100, 0.005)</SecHand>
+        <MainHand>(-0.412, 0.100, 0.000)</MainHand>
+        <SecHand>(0.023, -0.100, 0.083)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_HeavyFlamer</li>
           <!-- heavy flamer -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.036, 0.100, 0.147)</MainHand>
-        <SecHand>(0.129, -0.100, 0.069)</SecHand>
+        <MainHand>(-0.357, 0.100, 0.060)</MainHand>
+        <SecHand>(0.056, -0.100, 0.138)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_SwarmMissileLauncher</li>
           <!-- swarm missile launcher -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.283, 0.100, -0.206)</MainHand>
-        <SecHand>(0.088, -0.100, -0.100)</SecHand>
+        <MainHand>(-0.412, 0.100, 0.101)</MainHand>
+        <SecHand>(-0.215, -0.100, -0.243)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_UraniumSlugRifle</li>
           <!-- uranium slug rifle -->

--- a/1.2/Defs/Mods/VanillaExpanded.VWEQ.xml
+++ b/1.2/Defs/Mods/VanillaExpanded.VWEQ.xml
@@ -13,7 +13,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.190, 0.100, -0.078)</MainHand>
+        <MainHand>(-0.178, 0.100, -0.078)</MainHand>
         <SecHand>(0.175, -0.100, -0.018)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_BullpupDMR</li>
@@ -21,8 +21,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.219, 0.100, -0.096)</MainHand>
-        <SecHand>(-0.033, -0.100, -0.050)</SecHand>
+        <MainHand>(-0.027, 0.100, -0.114)</MainHand>
+        <SecHand>(0.234, -0.100, -0.045)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_BullpupRifle</li>
           <!-- bullpup rifle -->
@@ -30,7 +30,7 @@
       </li>
       <li>
         <MainHand>(-0.026, 0.100, -0.110)</MainHand>
-        <SecHand>(0.168, -0.100, -0.133)</SecHand>
+        <SecHand>(0.267, -0.100, -0.151)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_PDW</li>
           <!-- PDW -->

--- a/1.2/Defs/Mods/VanillaExpanded.VWETB.xml
+++ b/1.2/Defs/Mods/VanillaExpanded.VWETB.xml
@@ -36,7 +36,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.045, 0.100, -0.239)</MainHand>
+        <MainHand>(-0.018, 0.100, -0.169)</MainHand>
         <ThingTargets>
           <li>VWE_Throwing_Shards</li>
           <!-- throwing shards -->
@@ -50,8 +50,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.253, -0.100, -0.050)</MainHand>
-        <SecHand>(0.269, 0.100, -0.050)</SecHand>
+        <MainHand>(-0.027, 0.100, -0.050)</MainHand>
         <ThingTargets>
           <li>VWE_Weapon_FireBomb</li>
           <!-- fire bombs -->

--- a/1.2/Defs/ThingDefs/Core.xml
+++ b/1.2/Defs/ThingDefs/Core.xml
@@ -302,6 +302,36 @@
           <li>MeleeWeapon_Zeushammer</li>
         </ThingTargets>
       </li>
+      <li>
+        <MainHand>(-0.144, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>MeleeWeapon_BreachAxe</li>
+          <!-- breach axe -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(0.164, 0.100, 0.000)</MainHand>
+        <SecHand>(-0.092, -0.100, 0.000)</SecHand>
+        <ThingTargets>
+          <li>Flamebow</li>
+          <!-- flamebow -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.041, 0.100, -0.100)</MainHand>
+        <ThingTargets>
+          <li>Weapon_GrenadeTox</li>
+          <!-- tox grenades -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.142, 0.100, -0.179)</MainHand>
+        <SecHand>(0.163, -0.100, -0.169)</SecHand>
+        <ThingTargets>
+          <li>Gun_ToxbombLauncher</li>
+          <!-- toxbomb launcher -->
+        </ThingTargets>
+      </li>
     </WeaponCompLoader>
   </WHands.ClutterHandsTDef>
 </Defs>

--- a/1.3/Defs/Mods/CEGuns.xml
+++ b/1.3/Defs/Mods/CEGuns.xml
@@ -30,6 +30,14 @@
         </ThingTargets>
       </li>
       <li>
+        <MainHand>(-0.165, 0.100, -0.087)</MainHand>
+        <SecHand>(0.308, -0.100, -0.050)</SecHand>
+        <ThingTargets>
+          <li>CE_Gun_FlintlockBlunderbuss</li>
+          <!-- flintlock blunderbuss -->
+        </ThingTargets>
+      </li>
+      <li>
         <MainHand>(-0.279, 0.100, 0.005)</MainHand>
         <SecHand>(0.202, -0.100, 0.019)</SecHand>
         <ThingTargets>

--- a/1.3/Defs/Mods/CETeam.CombatExtended.xml
+++ b/1.3/Defs/Mods/CETeam.CombatExtended.xml
@@ -6,8 +6,7 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.129, 0.100, -0.050)</MainHand>
-        <SecHand>(-0.046, -0.100, 0.128)</SecHand>
+        <MainHand>(-0.064, 0.100, -0.050)</MainHand>
         <ThingTargets>
           <li>Gun_BinocularsRadio</li>
           <!-- binoculars -->
@@ -69,6 +68,13 @@
         <ThingTargets>
           <li>CE_FlareGun</li>
           <!-- flare gun -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.362, 0.100, -0.059)</MainHand>
+        <ThingTargets>
+          <li>Pila</li>
+          <!-- javelins -->
         </ThingTargets>
       </li>
     </WeaponCompLoader>

--- a/1.3/Defs/Mods/ReinforcedMechanoids2.xml
+++ b/1.3/Defs/Mods/ReinforcedMechanoids2.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="hlx.reinforcedmechanoids2">
+    <defName>ClutterHandsSettings_ReinforcedMechanoid2</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.252, 0.100, -0.073)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ARCPistol</li>
+          <!-- ARC pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.344, 0.100, -0.082)</MainHand>
+        <SecHand>(0.133, -0.100, -0.110)</SecHand>
+        <ThingTargets>
+          <li>RM_ARCRifle</li>
+          <!-- ARC rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.270, 0.100, 0.023)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargeLancePistol</li>
+          <!-- charge lance pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.266, 0.100, -0.137)</MainHand>
+        <SecHand>(0.299, -0.100, -0.082)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargeLanceRifle</li>
+          <!-- charge lance rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.289, 0.100, -0.018)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargePistol</li>
+          <!-- charge pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.215, 0.100, -0.073)</MainHand>
+        <SecHand>(0.092, 0.100, -0.220)</SecHand>
+        <ThingTargets>
+          <li>RM_Weapon_GrenadePlasmaImmolator</li>
+          <!-- immolator grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.064, 0.100, 0.111)</MainHand>
+        <SecHand>(0.156, 0.100, 0.000)</SecHand>
+        <ThingTargets>
+          <li>RM_Weapon_GrenadePlasmaImmolator_V</li>
+          <!-- immolator grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.422, 0.100, -0.050)</MainHand>
+        <SecHand>(0.175, -0.100, 0.202)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_InfernoLauncher</li>
+          <!-- inferno launcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.169, 0.100, -0.160)</MainHand>
+        <SecHand>(0.152, -0.100, -0.114)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_InfernoRifle</li>
+          <!-- inferno rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.321, 0.100, -0.050)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ShardLance</li>
+          <!-- shard lance -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.247, 0.100, -0.009)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ShardLauncher</li>
+          <!-- shard launcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.192, 0.100, -0.206)</MainHand>
+        <ThingTargets>
+          <li>RM_MeleeWeapon_PlasmaBane</li>
+          <!-- plasma bane -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.211, 0.100, -0.206)</MainHand>
+        <ThingTargets>
+          <li>RM_MeleeWeapon_PlasmaSword</li>
+          <!-- plasma sword -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.3/Defs/Mods/TurretCollection.xml
+++ b/1.3/Defs/Mods/TurretCollection.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="eatkenny.leafzxg.dws.turretcollection">
+    <defName>ClutterHandsSettings_TurretCollectionUnofficial</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.156, 0.100, -0.091)</MainHand>
+        <SecHand>(0.225, -0.100, -0.174)</SecHand>
+        <ThingTargets>
+          <li>Gun_AATWS_TC</li>
+          <!-- AATWS -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.3/Defs/Mods/UltratechAlteredCarbon.xml
+++ b/1.3/Defs/Mods/UltratechAlteredCarbon.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="hlx.ultratechalteredcarbon">
+    <defName>ClutterHandsSettings_AlteredCarbonUltratechUnleashed</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.059, 0.100, -0.128)</MainHand>
+        <ThingTargets>
+          <li>AC_Gun_Autorevolver</li>
+          <!-- autorevolver -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.3/Defs/Mods/VFEE.xml
+++ b/1.3/Defs/Mods/VFEE.xml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="oskarpotocki.vfe.empire">
+    <defName>ClutterHandsSettings_VanillaFactionsExpandedEmpire</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.206, 0.100, -0.105)</MainHand>
+        <SecHand>(0.189, -0.100, -0.073)</SecHand>
+        <ThingTargets>
+          <li>VFEE_Gun_ChargeThumper</li>
+          <!-- charge thumper -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.261, 0.100, -0.087)</MainHand>
+        <SecHand>(0.101, -0.100, -0.082)</SecHand>
+        <ThingTargets>
+          <li>VEE_Gun_Fletcher</li>
+          <!-- fletcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.183, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>VFEE_MeleeWeapon_ToxbladeBladelink</li>
+          <!-- persona toxblade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.188, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>VFEE_MeleeWeapon_Toxblade</li>
+          <!-- toxblade -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.3/Defs/Mods/VWEFT.xml
+++ b/1.3/Defs/Mods/VWEFT.xml
@@ -59,7 +59,7 @@
       </li>
       <li>
         <MainHand>(-0.403, 0.100, 0.051)</MainHand>
-        <SecHand>(-0.156, -0.100, -0.233)</SecHand>
+        <SecHand>(-0.119, -0.100, 0.138)</SecHand>
         <ThingTargets>
           <li>VWEFT_Gun_HandheldGatlingGun</li>
           <!-- handheld gatling gun -->

--- a/1.3/Defs/Mods/VanillaExpanded.VWE.xml
+++ b/1.3/Defs/Mods/VanillaExpanded.VWE.xml
@@ -6,8 +6,8 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.194, 0.100, 0.189)</MainHand>
-        <SecHand>(0.023, -0.100, -0.270)</SecHand>
+        <MainHand>(-0.224, 0.100, 0.189)</MainHand>
+        <SecHand>(0.019, -0.100, -0.334)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_FireExtinguisher</li>
           <!-- fire extinguisher -->
@@ -29,8 +29,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(0.098, 0.100, -0.203)</MainHand>
-        <SecHand>(0.330, -0.100, -0.119)</SecHand>
+        <MainHand>(0.051, 0.100, -0.119)</MainHand>
+        <SecHand>(0.244, -0.100, -0.119)</SecHand>
         <ThingTargets>
           <li>Gun_DoomsdayRocket</li>
           <!-- doomsday rocket launcher -->
@@ -265,8 +265,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(0.014, 0.100, -0.180)</MainHand>
-        <SecHand>(0.204, -0.100, 0.127)</SecHand>
+        <MainHand>(-0.036, 0.100, -0.146)</MainHand>
+        <SecHand>(0.244, -0.100, -0.128)</SecHand>
         <ThingTargets>
           <li>Gun_TripleRocket</li>
           <!-- triple rocket launcher -->
@@ -281,14 +281,15 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.025, 0.100, -0.050)</MainHand>
+        <MainHand>(-0.252, 0.100, -0.013)</MainHand>
+        <SecHand>(0.184, 0.100, -0.247)</SecHand>
         <ThingTargets>
           <li>VWE_Throwing_Rocks</li>
           <!-- throwing rocks -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.052, 0.100, -0.215)</MainHand>
+        <MainHand>(-0.004, 0.100, -0.156)</MainHand>
         <ThingTargets>
           <li>VWE_Throwing_Knives</li>
           <!-- throwing knives -->
@@ -327,7 +328,6 @@
       </li>
       <li>
         <MainHand>(-0.211, 0.100, -0.050)</MainHand>
-        <SecHand>(0.136, -0.100, -0.022)</SecHand>
         <ThingTargets>
           <li>VWE_SawedOffShotgun</li>
           <!-- sawed-off Shotgun -->
@@ -365,7 +365,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.324, 0.100, 0.000)</MainHand>
+        <MainHand>(-0.302, 0.100, 0.000)</MainHand>
+        <SecHand>(-0.105, -0.100, 0.000)</SecHand>
         <ThingTargets>
           <li>VWE_MeleeWeapon_Shovel</li>
           <!-- shovel -->

--- a/1.3/Defs/Mods/VanillaExpanded.VWEHW.xml
+++ b/1.3/Defs/Mods/VanillaExpanded.VWEHW.xml
@@ -6,40 +6,40 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.128, 0.100, 0.129)</MainHand>
-        <SecHand>(-0.023, -0.100, 0.092)</SecHand>
+        <MainHand>(-0.367, 0.100, 0.092)</MainHand>
+        <SecHand>(-0.041, -0.100, 0.143)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_Autocannon</li>
           <!-- autocannon -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.220, 0.100, 0.189)</MainHand>
-        <SecHand>(-0.071, -0.100, 0.161)</SecHand>
+        <MainHand>(-0.371, 0.100, -0.022)</MainHand>
+        <SecHand>(-0.123, -0.100, 0.225)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_HandheldMortar</li>
           <!-- handheld mortar -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.059, 0.100, 0.065)</MainHand>
-        <SecHand>(0.072, -0.100, 0.005)</SecHand>
+        <MainHand>(-0.412, 0.100, 0.000)</MainHand>
+        <SecHand>(0.023, -0.100, 0.083)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_HeavyFlamer</li>
           <!-- heavy flamer -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.036, 0.100, 0.147)</MainHand>
-        <SecHand>(0.129, -0.100, 0.069)</SecHand>
+        <MainHand>(-0.357, 0.100, 0.060)</MainHand>
+        <SecHand>(0.056, -0.100, 0.138)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_SwarmMissileLauncher</li>
           <!-- swarm missile launcher -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.283, 0.100, -0.206)</MainHand>
-        <SecHand>(0.088, -0.100, -0.100)</SecHand>
+        <MainHand>(-0.412, 0.100, 0.101)</MainHand>
+        <SecHand>(-0.215, -0.100, -0.243)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_UraniumSlugRifle</li>
           <!-- uranium slug rifle -->

--- a/1.3/Defs/Mods/VanillaExpanded.VWEQ.xml
+++ b/1.3/Defs/Mods/VanillaExpanded.VWEQ.xml
@@ -13,7 +13,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.190, 0.100, -0.078)</MainHand>
+        <MainHand>(-0.178, 0.100, -0.078)</MainHand>
         <SecHand>(0.175, -0.100, -0.018)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_BullpupDMR</li>
@@ -21,8 +21,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.219, 0.100, -0.096)</MainHand>
-        <SecHand>(-0.033, -0.100, -0.050)</SecHand>
+        <MainHand>(-0.027, 0.100, -0.114)</MainHand>
+        <SecHand>(0.234, -0.100, -0.045)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_BullpupRifle</li>
           <!-- bullpup rifle -->
@@ -30,7 +30,7 @@
       </li>
       <li>
         <MainHand>(-0.026, 0.100, -0.110)</MainHand>
-        <SecHand>(0.168, -0.100, -0.133)</SecHand>
+        <SecHand>(0.267, -0.100, -0.151)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_PDW</li>
           <!-- PDW -->

--- a/1.3/Defs/Mods/VanillaExpanded.VWETB.xml
+++ b/1.3/Defs/Mods/VanillaExpanded.VWETB.xml
@@ -36,7 +36,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.045, 0.100, -0.239)</MainHand>
+        <MainHand>(-0.018, 0.100, -0.169)</MainHand>
         <ThingTargets>
           <li>VWE_Throwing_Shards</li>
           <!-- throwing shards -->
@@ -50,8 +50,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.253, -0.100, -0.050)</MainHand>
-        <SecHand>(0.269, 0.100, -0.050)</SecHand>
+        <MainHand>(-0.027, 0.100, -0.050)</MainHand>
         <ThingTargets>
           <li>VWE_Weapon_FireBomb</li>
           <!-- fire bombs -->

--- a/1.3/Defs/ThingDefs/Core.xml
+++ b/1.3/Defs/ThingDefs/Core.xml
@@ -309,6 +309,29 @@
           <!-- breach axe -->
         </ThingTargets>
       </li>
+      <li>
+        <MainHand>(0.164, 0.100, 0.000)</MainHand>
+        <SecHand>(-0.092, -0.100, 0.000)</SecHand>
+        <ThingTargets>
+          <li>Flamebow</li>
+          <!-- flamebow -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.041, 0.100, -0.100)</MainHand>
+        <ThingTargets>
+          <li>Weapon_GrenadeTox</li>
+          <!-- tox grenades -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.142, 0.100, -0.179)</MainHand>
+        <SecHand>(0.163, -0.100, -0.169)</SecHand>
+        <ThingTargets>
+          <li>Gun_ToxbombLauncher</li>
+          <!-- toxbomb launcher -->
+        </ThingTargets>
+      </li>
     </WeaponCompLoader>
   </WHands.ClutterHandsTDef>
 </Defs>

--- a/1.4/Defs/Mods/CEGuns.xml
+++ b/1.4/Defs/Mods/CEGuns.xml
@@ -30,6 +30,14 @@
         </ThingTargets>
       </li>
       <li>
+        <MainHand>(-0.165, 0.100, -0.087)</MainHand>
+        <SecHand>(0.308, -0.100, -0.050)</SecHand>
+        <ThingTargets>
+          <li>CE_Gun_FlintlockBlunderbuss</li>
+          <!-- flintlock blunderbuss -->
+        </ThingTargets>
+      </li>
+      <li>
         <MainHand>(-0.279, 0.100, 0.005)</MainHand>
         <SecHand>(0.202, -0.100, 0.019)</SecHand>
         <ThingTargets>

--- a/1.4/Defs/Mods/CETeam.CombatExtended.xml
+++ b/1.4/Defs/Mods/CETeam.CombatExtended.xml
@@ -6,8 +6,7 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.129, 0.100, -0.050)</MainHand>
-        <SecHand>(-0.046, -0.100, 0.128)</SecHand>
+        <MainHand>(-0.064, 0.100, -0.050)</MainHand>
         <ThingTargets>
           <li>Gun_BinocularsRadio</li>
           <!-- binoculars -->
@@ -69,6 +68,13 @@
         <ThingTargets>
           <li>CE_FlareGun</li>
           <!-- flare gun -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.362, 0.100, -0.059)</MainHand>
+        <ThingTargets>
+          <li>Pila</li>
+          <!-- javelins -->
         </ThingTargets>
       </li>
     </WeaponCompLoader>

--- a/1.4/Defs/Mods/ReinforcedMechanoids2.xml
+++ b/1.4/Defs/Mods/ReinforcedMechanoids2.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="hlx.reinforcedmechanoids2">
+    <defName>ClutterHandsSettings_ReinforcedMechanoid2</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.252, 0.100, -0.073)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ARCPistol</li>
+          <!-- ARC pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.344, 0.100, -0.082)</MainHand>
+        <SecHand>(0.133, -0.100, -0.110)</SecHand>
+        <ThingTargets>
+          <li>RM_ARCRifle</li>
+          <!-- ARC rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.270, 0.100, 0.023)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargeLancePistol</li>
+          <!-- charge lance pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.266, 0.100, -0.137)</MainHand>
+        <SecHand>(0.299, -0.100, -0.082)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargeLanceRifle</li>
+          <!-- charge lance rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.289, 0.100, -0.018)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ChargePistol</li>
+          <!-- charge pistol -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.215, 0.100, -0.073)</MainHand>
+        <SecHand>(0.092, 0.100, -0.220)</SecHand>
+        <ThingTargets>
+          <li>RM_Weapon_GrenadePlasmaImmolator</li>
+          <!-- immolator grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.064, 0.100, 0.111)</MainHand>
+        <SecHand>(0.156, 0.100, 0.000)</SecHand>
+        <ThingTargets>
+          <li>RM_Weapon_GrenadePlasmaImmolator_V</li>
+          <!-- immolator grenade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.422, 0.100, -0.050)</MainHand>
+        <SecHand>(0.175, -0.100, 0.202)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_InfernoLauncher</li>
+          <!-- inferno launcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.169, 0.100, -0.160)</MainHand>
+        <SecHand>(0.152, -0.100, -0.114)</SecHand>
+        <ThingTargets>
+          <li>RM_Gun_InfernoRifle</li>
+          <!-- inferno rifle -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.321, 0.100, -0.050)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ShardLance</li>
+          <!-- shard lance -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.247, 0.100, -0.009)</MainHand>
+        <ThingTargets>
+          <li>RM_Gun_ShardLauncher</li>
+          <!-- shard launcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.192, 0.100, -0.206)</MainHand>
+        <ThingTargets>
+          <li>RM_MeleeWeapon_PlasmaBane</li>
+          <!-- plasma bane -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.211, 0.100, -0.206)</MainHand>
+        <ThingTargets>
+          <li>RM_MeleeWeapon_PlasmaSword</li>
+          <!-- plasma sword -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.4/Defs/Mods/TurretCollection.xml
+++ b/1.4/Defs/Mods/TurretCollection.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="eatkenny.leafzxg.dws.turretcollection">
+    <defName>ClutterHandsSettings_TurretCollectionUnofficial</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.156, 0.100, -0.091)</MainHand>
+        <SecHand>(0.225, -0.100, -0.174)</SecHand>
+        <ThingTargets>
+          <li>Gun_AATWS_TC</li>
+          <!-- AATWS -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.4/Defs/Mods/UltratechAlteredCarbon.xml
+++ b/1.4/Defs/Mods/UltratechAlteredCarbon.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="hlx.ultratechalteredcarbon">
+    <defName>ClutterHandsSettings_AlteredCarbonUltratechUnleashed</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.059, 0.100, -0.128)</MainHand>
+        <ThingTargets>
+          <li>AC_Gun_Autorevolver</li>
+          <!-- autorevolver -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.4/Defs/Mods/VFEE.xml
+++ b/1.4/Defs/Mods/VFEE.xml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <WHands.ClutterHandsTDef MayRequire="oskarpotocki.vfe.empire">
+    <defName>ClutterHandsSettings_VanillaFactionsExpandedEmpire</defName>
+    <label>Weapon hand settings</label>
+    <thingClass>Thing</thingClass>
+    <WeaponCompLoader>
+      <li>
+        <MainHand>(-0.206, 0.100, -0.105)</MainHand>
+        <SecHand>(0.189, -0.100, -0.073)</SecHand>
+        <ThingTargets>
+          <li>VFEE_Gun_ChargeThumper</li>
+          <!-- charge thumper -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.261, 0.100, -0.087)</MainHand>
+        <SecHand>(0.101, -0.100, -0.082)</SecHand>
+        <ThingTargets>
+          <li>VEE_Gun_Fletcher</li>
+          <!-- fletcher -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.183, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>VFEE_MeleeWeapon_ToxbladeBladelink</li>
+          <!-- persona toxblade -->
+        </ThingTargets>
+      </li>
+      <li>
+        <MainHand>(-0.188, 0.100, 0.000)</MainHand>
+        <ThingTargets>
+          <li>VFEE_MeleeWeapon_Toxblade</li>
+          <!-- toxblade -->
+        </ThingTargets>
+      </li>
+    </WeaponCompLoader>
+  </WHands.ClutterHandsTDef>
+</Defs>

--- a/1.4/Defs/Mods/VWEFT.xml
+++ b/1.4/Defs/Mods/VWEFT.xml
@@ -59,7 +59,7 @@
       </li>
       <li>
         <MainHand>(-0.403, 0.100, 0.051)</MainHand>
-        <SecHand>(-0.156, -0.100, -0.233)</SecHand>
+        <SecHand>(-0.119, -0.100, 0.138)</SecHand>
         <ThingTargets>
           <li>VWEFT_Gun_HandheldGatlingGun</li>
           <!-- handheld gatling gun -->

--- a/1.4/Defs/Mods/VanillaExpanded.VWE.xml
+++ b/1.4/Defs/Mods/VanillaExpanded.VWE.xml
@@ -6,8 +6,8 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.194, 0.100, 0.189)</MainHand>
-        <SecHand>(0.023, -0.100, -0.270)</SecHand>
+        <MainHand>(-0.224, 0.100, 0.189)</MainHand>
+        <SecHand>(0.019, -0.100, -0.334)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_FireExtinguisher</li>
           <!-- fire extinguisher -->
@@ -29,8 +29,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(0.098, 0.100, -0.203)</MainHand>
-        <SecHand>(0.330, -0.100, -0.119)</SecHand>
+        <MainHand>(0.051, 0.100, -0.119)</MainHand>
+        <SecHand>(0.244, -0.100, -0.119)</SecHand>
         <ThingTargets>
           <li>Gun_DoomsdayRocket</li>
           <!-- doomsday rocket launcher -->
@@ -265,8 +265,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(0.014, 0.100, -0.180)</MainHand>
-        <SecHand>(0.204, -0.100, 0.127)</SecHand>
+        <MainHand>(-0.036, 0.100, -0.146)</MainHand>
+        <SecHand>(0.244, -0.100, -0.128)</SecHand>
         <ThingTargets>
           <li>Gun_TripleRocket</li>
           <!-- triple rocket launcher -->
@@ -281,14 +281,15 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.025, 0.100, -0.050)</MainHand>
+        <MainHand>(-0.252, 0.100, -0.013)</MainHand>
+        <SecHand>(0.184, 0.100, -0.247)</SecHand>
         <ThingTargets>
           <li>VWE_Throwing_Rocks</li>
           <!-- throwing rocks -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.052, 0.100, -0.215)</MainHand>
+        <MainHand>(-0.004, 0.100, -0.156)</MainHand>
         <ThingTargets>
           <li>VWE_Throwing_Knives</li>
           <!-- throwing knives -->
@@ -327,7 +328,6 @@
       </li>
       <li>
         <MainHand>(-0.211, 0.100, -0.050)</MainHand>
-        <SecHand>(0.136, -0.100, -0.022)</SecHand>
         <ThingTargets>
           <li>VWE_SawedOffShotgun</li>
           <!-- sawed-off Shotgun -->
@@ -365,7 +365,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.324, 0.100, 0.000)</MainHand>
+        <MainHand>(-0.302, 0.100, 0.000)</MainHand>
+        <SecHand>(-0.105, -0.100, 0.000)</SecHand>
         <ThingTargets>
           <li>VWE_MeleeWeapon_Shovel</li>
           <!-- shovel -->

--- a/1.4/Defs/Mods/VanillaExpanded.VWEHW.xml
+++ b/1.4/Defs/Mods/VanillaExpanded.VWEHW.xml
@@ -6,40 +6,40 @@
     <thingClass>Thing</thingClass>
     <WeaponCompLoader>
       <li>
-        <MainHand>(-0.128, 0.100, 0.129)</MainHand>
-        <SecHand>(-0.023, -0.100, 0.092)</SecHand>
+        <MainHand>(-0.367, 0.100, 0.092)</MainHand>
+        <SecHand>(-0.041, -0.100, 0.143)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_Autocannon</li>
           <!-- autocannon -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.220, 0.100, 0.189)</MainHand>
-        <SecHand>(-0.071, -0.100, 0.161)</SecHand>
+        <MainHand>(-0.371, 0.100, -0.022)</MainHand>
+        <SecHand>(-0.123, -0.100, 0.225)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_HandheldMortar</li>
           <!-- handheld mortar -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.059, 0.100, 0.065)</MainHand>
-        <SecHand>(0.072, -0.100, 0.005)</SecHand>
+        <MainHand>(-0.412, 0.100, 0.000)</MainHand>
+        <SecHand>(0.023, -0.100, 0.083)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_HeavyFlamer</li>
           <!-- heavy flamer -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.036, 0.100, 0.147)</MainHand>
-        <SecHand>(0.129, -0.100, 0.069)</SecHand>
+        <MainHand>(-0.357, 0.100, 0.060)</MainHand>
+        <SecHand>(0.056, -0.100, 0.138)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_SwarmMissileLauncher</li>
           <!-- swarm missile launcher -->
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.283, 0.100, -0.206)</MainHand>
-        <SecHand>(0.088, -0.100, -0.100)</SecHand>
+        <MainHand>(-0.412, 0.100, 0.101)</MainHand>
+        <SecHand>(-0.215, -0.100, -0.243)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_UraniumSlugRifle</li>
           <!-- uranium slug rifle -->

--- a/1.4/Defs/Mods/VanillaExpanded.VWEQ.xml
+++ b/1.4/Defs/Mods/VanillaExpanded.VWEQ.xml
@@ -13,7 +13,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.190, 0.100, -0.078)</MainHand>
+        <MainHand>(-0.178, 0.100, -0.078)</MainHand>
         <SecHand>(0.175, -0.100, -0.018)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_BullpupDMR</li>
@@ -21,8 +21,8 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.219, 0.100, -0.096)</MainHand>
-        <SecHand>(-0.033, -0.100, -0.050)</SecHand>
+        <MainHand>(-0.027, 0.100, -0.114)</MainHand>
+        <SecHand>(0.234, -0.100, -0.045)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_BullpupRifle</li>
           <!-- bullpup rifle -->
@@ -30,7 +30,7 @@
       </li>
       <li>
         <MainHand>(-0.026, 0.100, -0.110)</MainHand>
-        <SecHand>(0.168, -0.100, -0.133)</SecHand>
+        <SecHand>(0.267, -0.100, -0.151)</SecHand>
         <ThingTargets>
           <li>VWE_Gun_PDW</li>
           <!-- PDW -->

--- a/1.4/Defs/Mods/VanillaExpanded.VWETB.xml
+++ b/1.4/Defs/Mods/VanillaExpanded.VWETB.xml
@@ -36,7 +36,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.045, 0.100, -0.239)</MainHand>
+        <MainHand>(-0.018, 0.100, -0.169)</MainHand>
         <ThingTargets>
           <li>VWE_Throwing_Shards</li>
           <!-- throwing shards -->
@@ -50,8 +50,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.253, -0.100, -0.050)</MainHand>
-        <SecHand>(0.269, 0.100, -0.050)</SecHand>
+        <MainHand>(-0.027, 0.100, -0.050)</MainHand>
         <ThingTargets>
           <li>VWE_Weapon_FireBomb</li>
           <!-- fire bombs -->

--- a/1.4/Defs/ThingDefs/Core.xml
+++ b/1.4/Defs/ThingDefs/Core.xml
@@ -318,7 +318,7 @@
         </ThingTargets>
       </li>
       <li>
-        <MainHand>(-0.019, 0.100, 0.128)</MainHand>
+        <MainHand>(-0.041, 0.100, -0.100)</MainHand>
         <ThingTargets>
           <li>Weapon_GrenadeTox</li>
           <!-- tox grenades -->


### PR DESCRIPTION
- Reinforced Mechanoids 2
- Turret Collection Unofficial
- Ultratech: Altered Carbon
- Vanilla Factions Expanded: Empire
- Missing blunderbuss from Combat Extended Guns
- Missing pila from Combat Extended
- Minor corrections to the fire extinguisher, doomsday rocket launcher, triple rocket launcher, throwing rocks, throwing knives, sawed off shotgun, and shovel from VWE
- Minor corrections to the autocannon, handheld mortar, heavy flamer, swarm missile launcher, and uranium slug rifle from VWE Heavy Weapons
- Minor corrections to the bullpup dmr, bullpup rifle, and pdw from VWE Quickdraw
- Minor corrections to the throwing shards and fire bombs from VWE Tribal
- Minor correction to the handheld gatling gun from VWE Frontier
- Minor correction to the tox grenade from Biotech